### PR TITLE
Bump pydicom past path-traversal advisory and pin dependency floors

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "interactive": ["curses"],
         "test": ["pytest-asyncio"]
     },
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         ]
     },
     install_requires=[
-        "pydicom==2.4.4",
+        "pydicom>=2.4.5,<3",
         "pandas",
         "tabulate",
         "scipy",

--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,20 @@ setup(
             "dicompare=dicompare.cli.main:main",
         ]
     },
+    # Lower bounds only (no upper caps except pydicom, which has breaking changes
+    # in 3.0). Floors are kept at or below the versions bundled by Pyodide 0.27.0
+    # — pandas 2.2.3 / scipy 1.14.1 / numpy 2.0.2 / tqdm 4.66.2 / jsonschema 4.21.1
+    # — because the web build resolves the compiled packages from Pyodide, so a
+    # floor above those would break `micropip.install('dicompare')` in the browser.
     install_requires=[
         "pydicom>=2.4.5,<3",
-        "pandas",
-        "tabulate",
-        "scipy",
-        "tqdm",
-        "nibabel",
-        "twixtools",
-        "jsonschema"
+        "pandas>=2.0",
+        "tabulate>=0.9.0",
+        "scipy>=1.10",
+        "tqdm>=4.60",
+        "nibabel>=5.0.0",
+        "twixtools>=0.24",
+        "jsonschema>=4.18",
     ],
     extras_require={
         "interactive": ["curses"],


### PR DESCRIPTION
## Summary

Fixes the pydicom path-traversal advisory and pins lower bounds on the remaining runtime dependencies.

## Changes
- **pydicom**: `==2.4.4` → `>=2.4.5,<3` to pick up the fix for [GHSA-v856-2rf8-9f28](https://github.com/advisories/GHSA-v856-2rf8-9f28). Capped below 3.0 because pydicom 3.0 has breaking API changes.
- **Lower-bound floors** on the other runtime deps (pandas `>=2.0`, tabulate `>=0.9.0`, scipy `>=1.10`, tqdm `>=4.60`, nibabel `>=5.0.0`, twixtools `>=0.24`, jsonschema `>=4.18`) instead of unpinned.
- **Drop Python 3.8/3.9 support**: pydicom 2.4.5 requires Python `>=3.10`, so 3.8/3.9 cannot install the security fix. Both are already end of life (3.8: 2024-10, 3.9: 2025-10). Updated `python_requires` and removed 3.8/3.9 from the package + publish CI matrices.

## Constraint note
Floors are deliberately kept at or below the versions bundled by Pyodide 0.27.0 (pandas 2.2.3 / scipy 1.14.1 / numpy 2.0.2 / tqdm 4.66.2 / jsonschema 4.21.1). The web build resolves the compiled packages from Pyodide, so a floor above those would break `micropip.install('dicompare')` in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)