### PR TITLE
Raise test coverage to 98% and enforce a 90% gate

### DIFF
--- a/dicompare/interface/web_utils.py
+++ b/dicompare/interface/web_utils.py
@@ -1155,17 +1155,22 @@ def search_dicom_dictionary(query: str, limit: int = 20) -> List[Dict[str, Any]]
         List of matching field dictionaries with:
         - tag, name, keyword, vr, vm, description, suggested_data_type
     """
-    from pydicom.datadict import keyword_for_tag, dictionary_VR, dictionary_VM, dictionary_description
+    from pydicom.datadict import DicomDictionary, dictionary_VR, dictionary_VM, dictionary_description
     from ..schema.tags import VR_TO_DATA_TYPE
 
     query_lower = query.lower()
     results = []
     count = 0
 
-    # Search through pydicom's keyword dictionary
-    for tag_int, keyword in keyword_for_tag.items():
+    # Search through pydicom's DICOM dictionary (tag_int -> (VR, VM, name,
+    # is_retired, keyword)). Note keyword_for_tag is a function, not a mapping.
+    for tag_int, entry in DicomDictionary.items():
         if count >= limit:
             break
+
+        keyword = entry[4]
+        if not keyword:
+            continue
 
         # Convert tag to string format
         tag_str = f"{tag_int:08X}"
@@ -1244,10 +1249,11 @@ def build_schema_from_ui_acquisitions(
             actual_value = field.get('value')
             validation_rule = field.get('validationRule', {})
 
-            # Handle complex value objects
+            # Handle complex value objects (read nested validationRule before
+            # unwrapping the scalar value out of the dict)
             if isinstance(actual_value, dict) and ('validationRule' in actual_value or 'dataType' in actual_value):
-                actual_value = actual_value.get('value')
                 validation_rule = actual_value.get('validationRule', validation_rule)
+                actual_value = actual_value.get('value')
 
             # Apply validation rules to create flat structure
             rule_type = validation_rule.get('type', 'exact') if validation_rule else 'exact'

--- a/dicompare/tests/test_cli_coverage.py
+++ b/dicompare/tests/test_cli_coverage.py
@@ -1,0 +1,506 @@
+"""
+Coverage-focused unit tests for the dicompare CLI.
+
+Targets dicompare/cli/main.py and dicompare/cli/match.py:
+    - the argparse ``main()`` dispatcher (build / check / match / no-command / errors)
+    - the ``check_command`` output branches (mapping summary confidence levels,
+      unmapped acquisitions, verbose vs. summary output, compliant sessions)
+    - the ``match_command`` / ``load_schemas_from_paths`` edge cases
+      (directories, invalid schemas, non-json paths, no schemas, long names,
+      scoring exceptions).
+
+These tests only exercise the CLI; they do not modify source or other tests.
+"""
+
+import json
+import sys
+
+import pytest
+from argparse import Namespace
+
+import dicompare.cli.main as cli_main
+from dicompare.cli.main import main, check_command
+from dicompare.cli import match as cli_match
+from dicompare.cli.match import match_command, load_schemas_from_paths
+from dicompare.tests.test_dicom_factory import create_test_dicom_series
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                     #
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def dicom_dir(tmp_path):
+    """A directory with a single simple DICOM acquisition."""
+    d = tmp_path / "dicoms"
+    d.mkdir()
+    create_test_dicom_series(
+        str(d),
+        acquisition_name="T1_MPRAGE",
+        num_slices=3,
+        metadata_base={
+            'ProtocolName': 'T1_MPRAGE',
+            'RepetitionTime': 2000.0,
+            'EchoTime': 3.0,
+            'FlipAngle': 9.0,
+            'SliceThickness': 1.0,
+        },
+    )
+    return d
+
+
+@pytest.fixture
+def self_schema(tmp_path, dicom_dir):
+    """A schema built from ``dicom_dir`` so it matches exactly."""
+    schema_path = tmp_path / "schema.json"
+    _run(["build", str(dicom_dir), str(schema_path)])
+    return schema_path
+
+
+def _run(argv, monkeypatch=None):
+    """Invoke ``main()`` with a given argv (sys.argv[1:])."""
+    full = ["dicompare"] + argv
+    if monkeypatch is not None:
+        monkeypatch.setattr(sys, "argv", full)
+        return main()
+    # fall back to direct patching when no monkeypatch is supplied
+    old = sys.argv
+    sys.argv = full
+    try:
+        return main()
+    finally:
+        sys.argv = old
+
+
+# --------------------------------------------------------------------------- #
+# main() dispatcher: argument parsing & errors                                #
+# --------------------------------------------------------------------------- #
+
+def test_main_no_command_prints_help_and_exits(monkeypatch, capsys):
+    with pytest.raises(SystemExit) as exc:
+        _run([], monkeypatch)
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "usage" in out.lower()
+
+
+def test_main_help_flag(monkeypatch, capsys):
+    with pytest.raises(SystemExit) as exc:
+        _run(["--help"], monkeypatch)
+    # argparse exits 0 on --help
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "build" in out and "check" in out and "match" in out
+
+
+def test_main_unknown_command_errors(monkeypatch, capsys):
+    with pytest.raises(SystemExit) as exc:
+        _run(["frobnicate"], monkeypatch)
+    assert exc.value.code == 2  # argparse invalid choice
+
+
+def test_build_missing_args_errors(monkeypatch, capsys):
+    with pytest.raises(SystemExit) as exc:
+        _run(["build"], monkeypatch)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "required" in err.lower()
+
+
+def test_check_missing_args_errors(monkeypatch, capsys):
+    with pytest.raises(SystemExit) as exc:
+        _run(["check", "onlydicoms"], monkeypatch)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "required" in err.lower()
+
+
+def test_match_missing_dicoms_errors(monkeypatch, capsys):
+    with pytest.raises(SystemExit) as exc:
+        _run(["match", "--library"], monkeypatch)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "required" in err.lower()
+
+
+def test_match_requires_schemas_or_library(monkeypatch, capsys, dicom_dir):
+    with pytest.raises(SystemExit) as exc:
+        _run(["match", str(dicom_dir)], monkeypatch)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "schemas" in err.lower() or "library" in err.lower()
+
+
+# --------------------------------------------------------------------------- #
+# main() -> build_command                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_main_build_positional(monkeypatch, capsys, dicom_dir, tmp_path):
+    schema_path = tmp_path / "out_schema.json"
+    _run(["build", str(dicom_dir), str(schema_path)], monkeypatch)
+    out = capsys.readouterr().out
+    assert "JSON schema saved to" in out
+    assert schema_path.exists()
+    data = json.loads(schema_path.read_text())
+    assert "acquisitions" in data
+
+
+def test_main_build_named_args(monkeypatch, capsys, dicom_dir, tmp_path):
+    schema_path = tmp_path / "named_schema.json"
+    _run(
+        ["build", "--dicoms", str(dicom_dir), "--schema", str(schema_path)],
+        monkeypatch,
+    )
+    assert schema_path.exists()
+
+
+# --------------------------------------------------------------------------- #
+# main() -> check_command                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_main_check_compliant_verbose(monkeypatch, capsys, dicom_dir, self_schema, tmp_path):
+    report = tmp_path / "report.json"
+    _run(
+        ["check", str(dicom_dir), str(self_schema), str(report),
+         "--auto-yes", "--verbose"],
+        monkeypatch,
+    )
+    out = capsys.readouterr().out
+    assert "Acquisition Mapping:" in out
+    # exact match -> confidence "exact" and PASS lines shown in verbose mode
+    assert "exact" in out
+    assert "[PASS]" in out
+    assert "Compliance report saved to" in out
+    assert report.exists()
+    results = json.loads(report.read_text())
+    assert all(r.get("status") == "ok" for r in results)
+
+
+def test_main_check_named_args_summary(monkeypatch, capsys, dicom_dir, self_schema):
+    # non-verbose path -> summary line, no PASS lines printed
+    _run(
+        ["check", "--dicoms", str(dicom_dir), "--schema", str(self_schema),
+         "--auto-yes"],
+        monkeypatch,
+    )
+    out = capsys.readouterr().out
+    assert "passed" in out.lower()
+    assert "[PASS]" not in out  # passes hidden in non-verbose mode
+
+
+def test_check_command_confidence_and_failures(capsys, dicom_dir, self_schema, tmp_path):
+    """Drive check_command with a schema that mismatches -> FAIL/expected/got."""
+    schema = json.loads(self_schema.read_text())
+    # Force a mismatch by changing EchoTime to a value the DICOMs don't have.
+    for acq in schema["acquisitions"].values():
+        for f in acq["fields"]:
+            if f["field"] == "EchoTime":
+                f["value"] = 999.0
+    schema_path = tmp_path / "mismatch.json"
+    schema_path.write_text(json.dumps(schema))
+    report = tmp_path / "rep.json"
+
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schema=str(schema_path),
+        report=str(report),
+        auto_yes=True,
+        verbose=False,
+    )
+    check_command(args)
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "expected:" in out
+    assert "got:" in out
+    assert "--verbose" in out  # summary suggests --verbose when there are failures
+    assert report.exists()
+
+
+def test_check_command_unmapped_acquisition(capsys, dicom_dir, self_schema, tmp_path):
+    """A schema with an extra acquisition that has no input to map to."""
+    schema = json.loads(self_schema.read_text())
+    acqs = schema["acquisitions"]
+    (first_name, first_acq), = list(acqs.items())
+    # Duplicate the acquisition under a second name so there are two reference
+    # acquisitions but only one input acquisition -> one stays unmapped.
+    import copy
+    acqs["ExtraUnmappedAcq"] = copy.deepcopy(first_acq)
+    schema_path = tmp_path / "extra.json"
+    schema_path.write_text(json.dumps(schema))
+
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schema=str(schema_path),
+        report=None,  # no report -> exercise the "no report" branch
+        auto_yes=True,
+        verbose=False,
+    )
+    check_command(args)
+    out = capsys.readouterr().out
+    # Unmapped reference acquisition appears in mapping summary and/or WARN line
+    assert "unmapped" in out.lower()
+
+
+def test_check_command_no_verbose_attr(capsys, dicom_dir, self_schema, tmp_path):
+    """Namespace without 'verbose' -> getattr default False path."""
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schema=str(self_schema),
+        report=None,
+        auto_yes=True,
+    )
+    check_command(args)
+    out = capsys.readouterr().out
+    assert "passed" in out.lower()
+
+
+def test_check_command_interactive_skipped_when_not_tty(monkeypatch, capsys, dicom_dir, self_schema):
+    """With auto_yes False but stdin not a tty, interactive mapping is skipped."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schema=str(self_schema),
+        report=None,
+        auto_yes=False,
+        verbose=False,
+    )
+    check_command(args)  # should not hang / prompt
+    out = capsys.readouterr().out
+    assert "Acquisition Mapping:" in out
+
+
+def test_check_command_fully_compliant_no_fields(capsys, dicom_dir, self_schema, tmp_path):
+    """Schema acquisition with no fields -> empty results -> 'fully compliant' path."""
+    schema = json.loads(self_schema.read_text())
+    (name, acq), = list(schema["acquisitions"].items())
+    acq["fields"] = []
+    acq["series"] = []
+    schema_path = tmp_path / "nofields.json"
+    schema_path.write_text(json.dumps(schema))
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schema=str(schema_path),
+        report=None,
+        auto_yes=True,
+        verbose=False,
+    )
+    check_command(args)
+    out = capsys.readouterr().out
+    assert "fully compliant" in out.lower()
+
+
+@pytest.mark.parametrize("cost,label", [(2.0, "high"), (10.0, "medium"), (42.0, "low")])
+def test_check_command_confidence_levels(monkeypatch, capsys, dicom_dir, self_schema, cost, label):
+    """Patch cost_details so the 'high'/'medium'/'low' confidence branches run."""
+    real_map = cli_main.map_to_json_reference
+
+    def fake_map(in_session, json_schema, return_costs=False):
+        session_map, cost_details = real_map(in_session, json_schema, return_costs=True)
+        for ref in cost_details.get("assigned_costs", {}):
+            cost_details["assigned_costs"][ref] = cost
+        if return_costs:
+            return session_map, cost_details
+        return session_map
+
+    monkeypatch.setattr(cli_main, "map_to_json_reference", fake_map)
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schema=str(self_schema),
+        report=None,
+        auto_yes=True,
+        verbose=False,
+    )
+    check_command(args)
+    out = capsys.readouterr().out
+    assert label in out
+
+
+def test_check_command_interactive_mapping_invoked(monkeypatch, capsys, dicom_dir, self_schema):
+    """auto_yes False + tty True -> interactive_mapping_to_json_reference is called."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    called = {}
+
+    def fake_interactive(in_session, json_schema, initial_mapping=None):
+        called["yes"] = True
+        return initial_mapping
+
+    monkeypatch.setattr(cli_main, "interactive_mapping_to_json_reference", fake_interactive)
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schema=str(self_schema),
+        report=None,
+        auto_yes=False,
+        verbose=False,
+    )
+    check_command(args)
+    assert called.get("yes") is True
+
+
+def test_check_command_series_and_rule_name_printing(monkeypatch, capsys, dicom_dir, self_schema):
+    """Patch compliance results to exercise series/rule_name/verbose-PASS print branches."""
+    crafted = [
+        {"status": "error", "field": "EchoTime", "series": "s1",
+         "value": 5.0, "expected": 3.0, "message": "mismatch"},
+        {"status": "warning", "field": "FlipAngle", "rule_name": "MyRule",
+         "value": 10.0, "expected": 9.0, "message": "warn"},
+        {"status": "ok", "field": "RepetitionTime", "value": 2000.0,
+         "message": "Passed."},
+        {"status": "na", "field": "Unknown", "message": "OK"},
+    ]
+    monkeypatch.setattr(cli_main, "check_acquisition_compliance",
+                        lambda *a, **k: list(crafted))
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schema=str(self_schema),
+        report=None,
+        auto_yes=True,
+        verbose=True,  # verbose so the OK-with-value line prints too
+    )
+    check_command(args)
+    out = capsys.readouterr().out
+    assert "[FAIL] EchoTime [s1]" in out          # series branch (line ~148)
+    assert "MyRule: FlipAngle" in out             # rule_name branch (line ~150)
+    assert "[PASS] RepetitionTime (2000.0)" in out  # verbose ok-with-value branch
+    assert "[N/A]" in out
+    assert "1 passed" in out and "1 failed" in out and "1 warnings" in out
+
+
+# --------------------------------------------------------------------------- #
+# main() -> match_command                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_main_match_library(monkeypatch, capsys, dicom_dir, tmp_path):
+    report = tmp_path / "match.json"
+    _run(
+        ["match", str(dicom_dir), "--library", "--report", str(report), "--top", "2"],
+        monkeypatch,
+    )
+    out = capsys.readouterr().out
+    assert "Loading DICOM session" in out
+    assert "Loaded" in out
+    assert "Match report saved to" in out
+    assert report.exists()
+    data = json.loads(report.read_text())
+    for acq, matches in data.items():
+        assert len(matches) <= 2
+
+
+def test_main_match_named_dicoms(monkeypatch, capsys, dicom_dir, self_schema):
+    _run(
+        ["match", "--dicoms", str(dicom_dir), "--schemas", str(self_schema)],
+        monkeypatch,
+    )
+    out = capsys.readouterr().out
+    assert "=== " in out  # per-acquisition header printed
+
+
+# --------------------------------------------------------------------------- #
+# match.py: load_schemas_from_paths edge cases                                #
+# --------------------------------------------------------------------------- #
+
+def test_load_schemas_non_json_path_skipped(tmp_path, caplog):
+    txt = tmp_path / "notes.txt"
+    txt.write_text("hello")
+    result = load_schemas_from_paths([str(txt)])
+    assert result == {}
+
+
+def test_load_schemas_nonexistent_path_skipped(tmp_path):
+    result = load_schemas_from_paths([str(tmp_path / "does_not_exist")])
+    assert result == {}
+
+
+def test_load_schemas_invalid_json_file_skipped(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ not valid json")
+    result = load_schemas_from_paths([str(bad)])
+    assert result == {}
+
+
+def test_load_schemas_from_directory_with_index(tmp_path):
+    good = {
+        "name": "Dir Schema",
+        "acquisitions": {
+            "Acq": {"fields": [{"field": "EchoTime", "value": 30.0, "tag": "0018,0081"}], "series": []}
+        },
+    }
+    (tmp_path / "a.json").write_text(json.dumps(good))
+    (tmp_path / "index.json").write_text(json.dumps(["a.json"]))
+    (tmp_path / "bad.json").write_text("nope")
+    result = load_schemas_from_paths([str(tmp_path)])
+    assert len(result) == 1
+    assert not any("index.json" in k for k in result)
+
+
+# --------------------------------------------------------------------------- #
+# match.py: match_command branches                                            #
+# --------------------------------------------------------------------------- #
+
+def test_match_command_no_schemas_loaded(capsys, dicom_dir):
+    """schemas point to nothing loadable -> 'No schemas loaded' path, early return."""
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schemas=["/nonexistent/path.json"],
+        library=False,
+        report=None,
+        top=5,
+    )
+    match_command(args)
+    out = capsys.readouterr().out
+    assert "No schemas loaded" in out
+
+
+def test_match_command_long_name_truncation(capsys, dicom_dir, tmp_path):
+    """A very long schema name is truncated with '...' in the table output."""
+    long_name = "X" * 60
+    schema = {
+        "name": long_name,
+        "acquisitions": {
+            "Acq": {
+                "fields": [{"field": "RepetitionTime", "value": 2000.0, "tag": "0018,0080"}],
+                "series": [],
+            }
+        },
+    }
+    schema_path = tmp_path / "long.json"
+    schema_path.write_text(json.dumps(schema))
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schemas=[str(schema_path)],
+        library=False,
+        report=None,
+        top=5,
+    )
+    match_command(args)
+    out = capsys.readouterr().out
+    assert "..." in out
+    assert ("X" * 25) in out  # truncated prefix present
+
+
+def test_match_command_scoring_exception_skips(monkeypatch, capsys, dicom_dir, tmp_path):
+    """If scoring raises, that candidate is skipped and no matches are produced."""
+    schema = {
+        "name": "Boom",
+        "acquisitions": {
+            "Acq": {"fields": [{"field": "EchoTime", "value": 3.0, "tag": "0018,0081"}], "series": []}
+        },
+    }
+    schema_path = tmp_path / "boom.json"
+    schema_path.write_text(json.dumps(schema))
+
+    def _raise(*a, **k):
+        raise RuntimeError("scoring blew up")
+
+    monkeypatch.setattr(cli_match, "compute_compliance_score", _raise)
+
+    args = Namespace(
+        dicoms=str(dicom_dir),
+        schemas=[str(schema_path)],
+        library=False,
+        report=None,
+        top=5,
+    )
+    match_command(args)
+    out = capsys.readouterr().out
+    assert "No matching schemas found." in out

--- a/dicompare/tests/test_dicom_coverage.py
+++ b/dicompare/tests/test_dicom_coverage.py
@@ -655,7 +655,7 @@ def test_load_dicom_pasl_bolus_labeling_duration(tmp_path, monkeypatch):
 def test_load_dicom_ascconv_coil_and_accel(tmp_path, monkeypatch):
     ds = _make_base_dataset()
     ds.Manufacturer = "SIEMENS"
-    path = _write_dataset(ds, tmp_path / "sie.dcm")
+    path = _write_dataset(ds, tmp_path / "scan.dcm")
     monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
         "ucCoilCombineMode": 2,
         "sPat": {"lAccelFactPE": 3},

--- a/dicompare/tests/test_dicom_coverage.py
+++ b/dicompare/tests/test_dicom_coverage.py
@@ -1,0 +1,1177 @@
+"""
+Coverage-focused unit tests for dicompare/io/dicom.py.
+
+These tests exercise the DICOM field/value extraction helpers, the various
+metadata-manipulation helpers, the enhanced/regular DICOM processing paths,
+CSA / ASCCONV extraction, ASL inference branches, and the session-loading
+entry points. Tests assert real behaviour and use tmp_path for file IO.
+"""
+
+import os
+import asyncio
+
+import numpy as np
+import pandas as pd
+import pydicom
+import pytest
+from pydicom.dataset import Dataset, FileMetaDataset
+from pydicom.sequence import Sequence
+from pydicom.uid import UID, ExplicitVRLittleEndian
+from pydicom.valuerep import DT
+
+import dicompare.io.dicom as dio
+from dicompare.io.dicom import (
+    _extract_inferred_metadata,
+    _extract_csa_metadata,
+    _extract_ascconv,
+    _get_ascconv_value,
+    _process_dicom_element,
+    _extract_shared_functional_groups,
+    _process_enhanced_dicom,
+    _process_regular_dicom,
+    get_dicom_values,
+    _update_metadata,
+    _get_metadata_value,
+    _set_metadata_value,
+    _key_in_metadata,
+    load_dicom,
+    load_nifti_session,
+    async_load_dicom_session,
+    load_dicom_session,
+    _load_one_dicom_path,
+    _load_one_dicom_bytes,
+)
+
+
+# --------------------------------------------------------------------------
+# Helpers to build DICOM datasets
+# --------------------------------------------------------------------------
+
+def _make_base_dataset(**extra):
+    ds = Dataset()
+    ds.PatientName = "Test^Patient"
+    ds.PatientID = "123"
+    ds.StudyInstanceUID = "1.2.3.4.5"
+    ds.SeriesInstanceUID = "1.2.3.4.6"
+    ds.SOPInstanceUID = "1.2.3.4.7"
+    ds.Modality = "MR"
+    ds.SeriesNumber = "1"
+    ds.InstanceNumber = "1"
+
+    fm = FileMetaDataset()
+    fm.MediaStorageSOPClassUID = UID("1.2.840.10008.5.1.4.1.1.4")
+    fm.MediaStorageSOPInstanceUID = UID("1.2.3")
+    fm.ImplementationClassUID = UID("1.2.3.4")
+    fm.TransferSyntaxUID = ExplicitVRLittleEndian
+    ds.file_meta = fm
+
+    for k, v in extra.items():
+        setattr(ds, k, v)
+    return ds
+
+
+def _write_dataset(ds, path):
+    ds.save_as(str(path), write_like_original=False)
+    return str(path)
+
+
+# --------------------------------------------------------------------------
+# _extract_inferred_metadata
+# --------------------------------------------------------------------------
+
+def test_inferred_metadata_from_image_comments():
+    ds = _make_base_dataset()
+    ds.ImageComments = "Unaliased MB3/PE3 SENSE1"
+    meta = _extract_inferred_metadata(ds)
+    assert meta["MultibandFactor"] == 3
+    assert meta["MultibandAccelerationFactor"] == 3
+    assert meta["ParallelReductionFactorOutOfPlane"] == 3
+
+
+def test_inferred_metadata_from_protocol_name():
+    ds = _make_base_dataset()
+    ds.ProtocolName = "rest_mb4_bold"
+    meta = _extract_inferred_metadata(ds)
+    assert meta["MultibandFactor"] == 4
+
+
+def test_inferred_metadata_image_comments_takes_priority():
+    ds = _make_base_dataset()
+    ds.ImageComments = "Unaliased MB2/PE3"
+    ds.ProtocolName = "task_mb8_run"
+    meta = _extract_inferred_metadata(ds)
+    # ImageComments (MB2) wins over ProtocolName (mb8)
+    assert meta["MultibandFactor"] == 2
+
+
+def test_inferred_metadata_none_found():
+    ds = _make_base_dataset()
+    ds.ImageComments = "no multiband here"
+    ds.ProtocolName = "plain_t1"
+    assert _extract_inferred_metadata(ds) == {}
+
+
+# --------------------------------------------------------------------------
+# _extract_csa_metadata (via monkeypatched get_csa_header)
+# --------------------------------------------------------------------------
+
+def test_csa_metadata_none(monkeypatch):
+    monkeypatch.setattr(dio, "get_csa_header", lambda ds, kind: None)
+    assert _extract_csa_metadata(_make_base_dataset()) == {}
+
+
+def test_csa_metadata_no_tags_key(monkeypatch):
+    monkeypatch.setattr(dio, "get_csa_header", lambda ds, kind: {"something": 1})
+    assert _extract_csa_metadata(_make_base_dataset()) == {}
+
+
+def test_csa_metadata_scalar_list_and_fallbacks(monkeypatch):
+    csa = {
+        "tags": {
+            "B_value": {"items": ["1000"]},
+            "DiffusionGradientDirection": {"items": ["1.0", "0.0", "0.0"]},
+            "SliceMeasurementDuration": {"items": []},          # empty -> None
+            "GradientMode": {"items": ["Fast"]},                 # non-float scalar -> str
+            "B_matrix": {"items": ["1.5", "notnum"]},            # mixed list
+        }
+    }
+    monkeypatch.setattr(dio, "get_csa_header", lambda ds, kind: csa)
+    meta = _extract_csa_metadata(_make_base_dataset())
+    assert meta["DiffusionBValue"] == 1000.0
+    assert meta["DiffusionGradientOrientation"] == [1.0, 0.0, 0.0]
+    assert meta["SliceMeasurementDuration"] is None
+    assert meta["GradientMode"] == "Fast"
+    assert meta["B_matrix"] == [1.5, "notnum"]
+    # A tag not present at all resolves to None
+    assert meta["TotalReadoutTime"] is None
+
+
+# --------------------------------------------------------------------------
+# _extract_ascconv
+# --------------------------------------------------------------------------
+
+def _csa_series_bytes(ascconv_body):
+    return (
+        b"junk header bytes "
+        + b"### ASCCONV BEGIN ###\n"
+        + ascconv_body.encode("latin-1")
+        + b"\n### ASCCONV END ###"
+        + b" trailing"
+    )
+
+
+def test_ascconv_extract_vseries_tag():
+    ds = _make_base_dataset()
+    body = "ucCoilCombineMode = 1\nsPat.lAccelFactPE = 2\nlRepetitions = 17"
+    ds.add_new((0x0029, 0x1020), "OB", _csa_series_bytes(body))
+    parsed = _extract_ascconv(ds)
+    assert parsed["ucCoilCombineMode"] == 1
+    assert parsed["sPat"]["lAccelFactPE"] == 2
+    assert parsed["lRepetitions"] == 17
+
+
+def test_ascconv_extract_xa_tag():
+    ds = _make_base_dataset()
+    body = "ucCoilCombineMode = 2"
+    ds.add_new((0x0021, 0x1019), "OB", _csa_series_bytes(body))
+    parsed = _extract_ascconv(ds)
+    assert parsed["ucCoilCombineMode"] == 2
+
+
+def test_ascconv_no_csa_tag():
+    ds = _make_base_dataset()
+    assert _extract_ascconv(ds) == {}
+
+
+def test_ascconv_no_markers():
+    ds = _make_base_dataset()
+    ds.add_new((0x0029, 0x1020), "OB", b"some bytes without ascconv markers")
+    assert _extract_ascconv(ds) == {}
+
+
+def test_ascconv_empty_bytes_skipped():
+    ds = _make_base_dataset()
+    ds.add_new((0x0029, 0x1020), "OB", b"")
+    assert _extract_ascconv(ds) == {}
+
+
+def test_ascconv_parse_failure(monkeypatch):
+    ds = _make_base_dataset()
+    ds.add_new((0x0029, 0x1020), "OB", _csa_series_bytes("ucCoilCombineMode = 1"))
+    import twixtools.twixprot as tp
+    monkeypatch.setattr(tp, "parse_buffer", lambda text: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert _extract_ascconv(ds) == {}
+
+
+# --------------------------------------------------------------------------
+# _get_ascconv_value
+# --------------------------------------------------------------------------
+
+def test_get_ascconv_value_direct_and_default():
+    d = {"a": 5}
+    assert _get_ascconv_value(d, "a") == 5
+    assert _get_ascconv_value(d, "missing", default="x") == "x"
+
+
+def test_get_ascconv_value_nested_dict():
+    d = {"sPat": {"lAccelFactPE": 3}}
+    assert _get_ascconv_value(d, "sPat.lAccelFactPE") == 3
+
+
+def test_get_ascconv_value_nested_missing():
+    d = {"sPat": {"lAccelFactPE": 3}}
+    assert _get_ascconv_value(d, "sPat.nope", default="dflt") == "dflt"
+    assert _get_ascconv_value(d, "missing.child", default="dflt") == "dflt"
+
+
+def test_get_ascconv_value_array_index():
+    d = {"arr": [10, 20, 30]}
+    assert _get_ascconv_value(d, "arr.1") == 20
+    # Out of range index -> default
+    assert _get_ascconv_value(d, "arr.9", default=None) is None
+
+
+def test_get_ascconv_value_none_in_path():
+    d = {"a": None}
+    assert _get_ascconv_value(d, "a.b", default="d") == "d"
+
+
+def test_get_ascconv_value_returns_default_when_value_none():
+    d = {"a": {"b": None}}
+    assert _get_ascconv_value(d, "a.b", default="d") == "d"
+
+
+# --------------------------------------------------------------------------
+# _process_dicom_element
+# --------------------------------------------------------------------------
+
+def test_process_element_skips_pixel_data():
+    ds = _make_base_dataset()
+    ds.add_new((0x7FE0, 0x0010), "OB", b"\x00\x01")
+    elem = ds[(0x7FE0, 0x0010)]
+    assert _process_dicom_element(elem, skip_pixel_data=True) is None
+
+
+def test_process_element_bytes_returns_none():
+    ds = _make_base_dataset()
+    ds.add_new((0x0009, 0x0010), "OB", b"\x01\x02")
+    elem = ds[(0x0009, 0x0010)]
+    assert _process_dicom_element(elem) is None
+
+
+def test_process_element_multivalue_and_scalars():
+    ds = _make_base_dataset()
+    ds.ImageOrientationPatient = ["1", "0", "0", "0", "1", "0"]
+    elem = ds["ImageOrientationPatient"]
+    result = _process_dicom_element(elem)
+    assert isinstance(result, tuple)
+    assert result == (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+
+
+def test_process_element_empty_string_returns_none():
+    ds = _make_base_dataset()
+    ds.SeriesDescription = ""
+    elem = ds["SeriesDescription"]
+    assert _process_dicom_element(elem) is None
+
+
+def test_process_element_string_value():
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "T1w"
+    elem = ds["SeriesDescription"]
+    assert _process_dicom_element(elem) == "T1w"
+
+
+def test_process_element_datetime():
+    ds = _make_base_dataset()
+    ds.add_new((0x0008, 0x002A), "DT", DT("20240101120000.000000"))
+    elem = ds[(0x0008, 0x002A)]
+    result = _process_dicom_element(elem)
+    assert result == "2024-01-01 12:00:00"
+
+
+def test_process_element_nested_dataset():
+    inner = Dataset()
+    inner.EchoTime = "3.0"
+    outer = Dataset()
+    seq = Sequence([inner])
+    outer.add_new((0x0018, 0x9114), "SQ", seq)  # MREchoSequence
+    elem = outer[(0x0018, 0x9114)]
+    result = _process_dicom_element(elem)
+    # sequences -> tuple of converted dicts
+    assert isinstance(result, tuple)
+    assert result[0]["EchoTime"] == 3.0
+
+
+def test_process_element_unconvertible_returns_none():
+    # A value that is not str/int/float/DT/list and whose str conversion is
+    # empty -> None (line 358 fallback path).
+    ds = _make_base_dataset()
+    ds.add_new((0x0009, 0x0011), "SH", "")  # empty short string
+    elem = ds[(0x0009, 0x0011)]
+    assert _process_dicom_element(elem) is None
+
+
+# --------------------------------------------------------------------------
+# _extract_shared_functional_groups
+# --------------------------------------------------------------------------
+
+def test_shared_functional_groups_combined():
+    coil = Dataset()
+    coil.ReceiveCoilName = "HeadNeck_20"
+    coil.ReceiveCoilType = "MULTICOIL"
+    e1 = Dataset(); e1.MultiCoilElementName = "H1"
+    e2 = Dataset(); e2.MultiCoilElementName = "H2"
+    coil.MultiCoilDefinitionSequence = Sequence([e1, e2])
+    tx = Dataset(); tx.TransmitCoilName = "Body"
+    shared = Dataset()
+    shared.MRReceiveCoilSequence = Sequence([coil])
+    shared.MRTransmitCoilSequence = Sequence([tx])
+
+    result = _extract_shared_functional_groups(shared)
+    assert result["ReceiveCoilName"] == "HeadNeck_20"
+    assert result["ReceiveCoilType"] == "MULTICOIL"
+    assert result["MultiCoilElementCount"] == 2
+    assert result["MultiCoilElementNames"] == ["H1", "H2"]
+    assert result["TransmitCoilName"] == "Body"
+
+
+def test_shared_functional_groups_empty():
+    shared = Dataset()
+    assert _extract_shared_functional_groups(shared) == {}
+
+
+# --------------------------------------------------------------------------
+# Enhanced / regular DICOM processing + get_dicom_values
+# --------------------------------------------------------------------------
+
+def _make_enhanced_dataset():
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "Enhanced"
+
+    # Shared functional groups with coil info
+    coil = Dataset()
+    coil.ReceiveCoilName = "Head_32"
+    e1 = Dataset(); e1.MultiCoilElementName = "H1"
+    e2 = Dataset(); e2.MultiCoilElementName = "H2"
+    coil.MultiCoilDefinitionSequence = Sequence([e1, e2])
+    shared = Dataset()
+    shared.MRReceiveCoilSequence = Sequence([coil])
+    ds.SharedFunctionalGroupsSequence = Sequence([shared])
+
+    # Two per-frame groups: one with a single-item sequence, one with multi-item
+    frame1 = Dataset()
+    echo = Dataset(); echo.EffectiveEchoTime = 3.0
+    frame1.MREchoSequence = Sequence([echo])
+    frame1.InstanceNumber = "1"
+
+    frame2 = Dataset()
+    m1 = Dataset(); m1.EffectiveEchoTime = 3.0
+    m2 = Dataset(); m2.EffectiveEchoTime = 6.0
+    frame2.MREchoSequence = Sequence([m1, m2])  # multi-item sequence branch
+    frame2.ImageOrientationPatient = ["1", "0", "0", "0", "1", "0"]  # MultiValue branch
+    frame2.InstanceNumber = "2"
+
+    ds.PerFrameFunctionalGroupsSequence = Sequence([frame1, frame2])
+    return ds
+
+
+def test_get_dicom_values_enhanced():
+    ds = _make_enhanced_dataset()
+    rows = get_dicom_values(ds, skip_pixel_data=True)
+    assert isinstance(rows, list)
+    assert len(rows) == 2
+    assert rows[0]["FrameIndex"] == 0
+    assert rows[1]["FrameIndex"] == 1
+    # Shared coil metadata merged into every frame
+    assert rows[0]["MultiCoilElementCount"] == 2
+
+
+def test_get_dicom_values_regular():
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "T1w"
+    result = get_dicom_values(ds, skip_pixel_data=True)
+    assert isinstance(result, dict)
+    assert result["SeriesDescription"] == "T1w"
+
+
+def test_process_enhanced_dicom_skip_pixel():
+    ds = _make_enhanced_dataset()
+    ds.add_new((0x7FE0, 0x0010), "OB", b"\x00\x01")
+    rows = _process_enhanced_dicom(ds, skip_pixel_data=True)
+    assert all("PixelData" not in r for r in rows)
+
+
+def test_process_regular_dicom_direct():
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "reg"
+    result = _process_regular_dicom(ds)
+    assert result["SeriesDescription"] == "reg"
+
+
+# --------------------------------------------------------------------------
+# metadata helper functions (dict + list variants)
+# --------------------------------------------------------------------------
+
+def test_update_metadata_dict_and_list():
+    d = {"a": 1}
+    _update_metadata(d, {"b": 2})
+    assert d == {"a": 1, "b": 2}
+
+    lst = [{"a": 1}, {"a": 2}]
+    _update_metadata(lst, {"c": 9})
+    assert all(item["c"] == 9 for item in lst)
+
+
+def test_get_metadata_value_dict_and_list():
+    assert _get_metadata_value({"a": 5}, "a") == 5
+    assert _get_metadata_value({"a": 5}, "b", default="d") == "d"
+
+    lst = [{"a": None}, {"a": 7}]
+    assert _get_metadata_value(lst, "a") == 7
+    assert _get_metadata_value([{"x": 1}], "a", default="d") == "d"
+
+
+def test_set_metadata_value_dict_and_list():
+    d = {}
+    _set_metadata_value(d, "k", 3)
+    assert d["k"] == 3
+
+    lst = [{}, {}]
+    _set_metadata_value(lst, "k", 4)
+    assert all(item["k"] == 4 for item in lst)
+
+
+def test_key_in_metadata_dict_and_list():
+    assert _key_in_metadata({"a": 1}, "a")
+    assert not _key_in_metadata({"a": 1}, "b")
+    assert _key_in_metadata([{"a": 1}, {"b": 2}], "b")
+    assert not _key_in_metadata([{"a": 1}], "z")
+
+
+# --------------------------------------------------------------------------
+# load_dicom - core behaviour and branch coverage
+# --------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _no_csa_no_ascconv(monkeypatch):
+    """Default: no CSA header and no ASCCONV so non-Siemens tests are clean.
+
+    Individual tests override these as needed.
+    """
+    monkeypatch.setattr(dio, "get_csa_header", lambda ds, kind: None)
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {})
+
+
+def test_load_dicom_from_path(tmp_path):
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "T1w"
+    path = _write_dataset(ds, tmp_path / "a.dcm")
+    result = load_dicom(path)
+    assert result["SeriesDescription"] == "T1w"
+    assert result["PatientName"] == "Test^Patient"
+
+
+def test_load_dicom_from_bytes(tmp_path):
+    ds = _make_base_dataset()
+    path = _write_dataset(ds, tmp_path / "a.dcm")
+    with open(path, "rb") as f:
+        content = f.read()
+    result = load_dicom(content)
+    assert result["PatientName"] == "Test^Patient"
+
+
+def test_load_dicom_missing_file_raises(tmp_path):
+    with pytest.raises(Exception):
+        load_dicom(str(tmp_path / "does_not_exist.dcm"))
+
+
+def test_load_dicom_acquisition_plane_axial(tmp_path):
+    ds = _make_base_dataset()
+    ds.ImageOrientationPatient = ["1", "0", "0", "0", "1", "0"]
+    path = _write_dataset(ds, tmp_path / "ax.dcm")
+    result = load_dicom(path)
+    assert result["AcquisitionPlane"] == "axial"
+
+
+def test_load_dicom_acquisition_plane_sagittal(tmp_path):
+    ds = _make_base_dataset()
+    ds.ImageOrientationPatient = ["0", "1", "0", "0", "0", "1"]
+    path = _write_dataset(ds, tmp_path / "sag.dcm")
+    result = load_dicom(path)
+    assert result["AcquisitionPlane"] == "sagittal"
+
+
+def test_load_dicom_acquisition_plane_coronal(tmp_path):
+    ds = _make_base_dataset()
+    ds.ImageOrientationPatient = ["1", "0", "0", "0", "0", "1"]
+    path = _write_dataset(ds, tmp_path / "cor.dcm")
+    result = load_dicom(path)
+    assert result["AcquisitionPlane"] == "coronal"
+
+
+def test_load_dicom_coil_combined_from_private_tag(tmp_path):
+    ds = _make_base_dataset()
+    ds.add_new((0x0051, 0x100F), "LO", "HC1-6")  # range -> combined
+    path = _write_dataset(ds, tmp_path / "coil.dcm")
+    result = load_dicom(path)
+    assert result["CoilType"] == "Combined"
+
+
+def test_load_dicom_coil_uncombined_from_private_tag(tmp_path):
+    ds = _make_base_dataset()
+    ds.add_new((0x0051, 0x100F), "LO", "H15")  # single element -> uncombined
+    path = _write_dataset(ds, tmp_path / "coil2.dcm")
+    result = load_dicom(path)
+    assert result["CoilType"] == "Uncombined"
+
+
+def test_load_dicom_coil_combined_semicolon(tmp_path):
+    ds = _make_base_dataset()
+    ds.add_new((0x0051, 0x100F), "LO", "HEA;HEP")
+    path = _write_dataset(ds, tmp_path / "coil3.dcm")
+    result = load_dicom(path)
+    assert result["CoilType"] == "Combined"
+
+
+def test_load_dicom_coil_combined_no_digits(tmp_path):
+    ds = _make_base_dataset()
+    ds.add_new((0x0051, 0x100F), "LO", "HEA")
+    path = _write_dataset(ds, tmp_path / "coil4.dcm")
+    result = load_dicom(path)
+    assert result["CoilType"] == "Combined"
+
+
+def test_load_dicom_coil_from_element_count(tmp_path, monkeypatch):
+    # Enhanced DICOM path: MultiCoilElementCount drives CoilType when no private tag.
+    ds = _make_enhanced_dataset()
+    path = _write_dataset(ds, tmp_path / "enh.dcm")
+    result = load_dicom(path)
+    # result is a list of frame dicts; count of 2 -> Combined
+    assert isinstance(result, list)
+    assert all(r["CoilType"] == "Combined" for r in result)
+
+
+def test_load_dicom_ge_image_type_mapping(tmp_path):
+    ds = _make_base_dataset()
+    ds.ImageType = ["ORIGINAL", "PRIMARY"]
+    ds.add_new((0x0043, 0x102F), "SS", 1)  # -> 'P'
+    path = _write_dataset(ds, tmp_path / "ge.dcm")
+    result = load_dicom(path)
+    assert "P" in result["ImageType"]
+
+
+def test_load_dicom_ge_image_type_no_existing(tmp_path):
+    ds = _make_base_dataset()
+    ds.add_new((0x0043, 0x102F), "SS", 0)  # -> 'M'
+    # Remove ImageType if implicitly present
+    path = _write_dataset(ds, tmp_path / "ge2.dcm")
+    result = load_dicom(path)
+    assert result["ImageType"] == ["M"]
+
+
+def test_load_dicom_siemens_xa_phase_encoding(tmp_path):
+    ds = _make_base_dataset()
+    ds.add_new((0x0021, 0x111C), "IS", "1")
+    path = _write_dataset(ds, tmp_path / "xa.dcm")
+    result = load_dicom(path)
+    assert result["PhaseEncodingDirectionPositive"] == 1
+
+
+def test_load_dicom_philips_asl_trigger_delay(tmp_path):
+    # 'TriggerDelayTime' is not a standard DICOM keyword; register a data
+    # dictionary entry so the metadata dict exposes it (as Philips scanners do
+    # via their private tag), which drives the Philips PostLabelDelay branch.
+    from pydicom.datadict import add_dict_entry
+    add_dict_entry(0x00181062, "DS", "TriggerDelayTime", "TriggerDelayTime")
+
+    ds = _make_base_dataset()
+    ds.Manufacturer = "Philips"
+    ds.add_new(0x00181062, "DS", "1800.0")  # TriggerDelayTime
+    path = _write_dataset(ds, tmp_path / "phil.dcm")
+    result = load_dicom(path)
+    assert result["PostLabelDelay"] == pytest.approx(1.8)
+
+
+def test_load_dicom_asl_type_from_protocol_name(tmp_path):
+    ds = _make_base_dataset()
+    ds.ImageType = ["ORIGINAL", "PRIMARY", "ASL"]
+    ds.ProtocolName = "my_pcasl_scan"
+    path = _write_dataset(ds, tmp_path / "asl.dcm")
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PCASL"
+
+
+def test_load_dicom_asl_type_pasl_name(tmp_path):
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "ep2d_pasl_run"
+    path = _write_dataset(ds, tmp_path / "pasl.dcm")
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PASL"
+
+
+def test_load_dicom_asl_type_casl_name(tmp_path):
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "some_casl_thing"
+    path = _write_dataset(ds, tmp_path / "casl.dcm")
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "CASL"
+
+
+def test_load_dicom_labeling_duration_from_tag_duration(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "ld.dcm")
+    # Inject TagDuration via CSA metadata
+    monkeypatch.setattr(dio, "_extract_csa_metadata", lambda ds: {"TagDuration": 1.5})
+    result = load_dicom(path)
+    assert result["LabelingDuration"] == 1.5
+
+
+def test_load_dicom_labeling_duration_from_rf_blocks(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "ld2.dcm")
+    monkeypatch.setattr(dio, "_extract_csa_metadata", lambda ds: {"NumRFBlocks": 20, "RFGap": 0.001})
+    result = load_dicom(path)
+    assert result["LabelingDuration"] == pytest.approx(0.02)
+
+
+def test_load_dicom_pasl_bolus_labeling_duration(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    ds.SeriesDescription = "pasl_scan"
+    path = _write_dataset(ds, tmp_path / "pasl2.dcm")
+    monkeypatch.setattr(dio, "_extract_csa_metadata", lambda ds: {"BolusDuration": 0.7, "InversionTime": 1.8})
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PASL"
+    assert result["LabelingDuration"] == 0.7
+
+
+# --------------------------------------------------------------------------
+# load_dicom - Siemens ASCCONV branches
+# --------------------------------------------------------------------------
+
+def test_load_dicom_ascconv_coil_and_accel(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "sie.dcm")
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
+        "ucCoilCombineMode": 2,
+        "sPat": {"lAccelFactPE": 3},
+    })
+    result = load_dicom(path)
+    assert result["CoilCombinationMethod"] == "Adaptive Combine"
+    assert result["AccelerationFactorPE"] == 3
+
+
+def test_load_dicom_ascconv_coil_unknown_mode(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "sie2.dcm")
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {"ucCoilCombineMode": 9})
+    result = load_dicom(path)
+    assert result["CoilCombinationMethod"] == "Unknown (9)"
+
+
+def test_load_dicom_ascconv_product_pcasl(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "pcasl.dcm")
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
+        "sAsl": {"ulMode": 1},
+        "tSequenceFileName": "%SiemensSeq%\\ep2d_pcasl",
+        "sWipMemBlock": {"adFree": [0.0, 60.0, 1800000.0]},
+    })
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PCASL"
+    assert result["LabelOffset"] == 60.0
+    assert result["PostLabelDelay"] == pytest.approx(1.8)
+    assert result["PulseSequenceDetails"] == "%SiemensSeq%\\ep2d_pcasl"
+
+
+def test_load_dicom_ascconv_pasl(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "asclpasl.dcm")
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
+        "sAsl": {"ulMode": 2},
+        "tSequenceFileName": "%SiemensSeq%\\ep2d_pasl",
+        "alTI": [700000.0, 0.0, 1800000.0],
+    })
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PASL"
+    assert result["BolusDuration"] == pytest.approx(0.7)
+    assert result["InversionTime"] == pytest.approx(1.8)
+
+
+def test_load_dicom_ascconv_vessel_encoded_2d(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "vepcasl.dcm")
+    alFree = [0] * 32
+    alFree[4] = 25.0        # flip angle
+    alFree[5] = 500.0       # duration us
+    alFree[6] = 100.0       # separation us
+    alFree[10] = 4000.0     # t1opt ms
+    alFree[11] = 1000.0     # PLD ms
+    alFree[12] = 1500.0     # PLD ms
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
+        "sAsl": {"ulMode": 2},
+        "tSequenceFileName": "%CustomerSeq%\\to_ep2d_VEPCASL",
+        "sWipMemBlock": {"alFree": alFree},
+    })
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PCASL"
+    assert result["TagRFFlipAngle"] == 25.0
+    assert result["TagRFDuration"] == pytest.approx(0.0005)
+    assert result["TagRFSeparation"] == pytest.approx(0.0001)
+    assert result["MaximumT1Opt"] == pytest.approx(4.0)
+    assert result["InitialPostLabelDelay"] == pytest.approx([1.0, 1.5])
+
+
+def test_load_dicom_ascconv_vessel_encoded_3d(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "vepcasl3d.dcm")
+    alFree = [0] * 40
+    alFree[6] = 30.0
+    alFree[7] = 600.0
+    alFree[8] = 120.0
+    alFree[9] = 3500.0
+    alFree[30] = 900.0
+    alFree[31] = 1400.0
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
+        "tSequenceFileName": "%CustomerSeq%\\jw_tgse_VEPCASL",
+        "sWipMemBlock": {"alFree": alFree},
+    })
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PCASL"
+    assert result["TagRFFlipAngle"] == 30.0
+    assert result["InitialPostLabelDelay"] == pytest.approx([0.9, 1.4])
+
+
+def test_load_dicom_ascconv_lrepetitions(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "reps.dcm")
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {"lRepetitions": 17})
+    result = load_dicom(path)
+    assert result["NumberOfTemporalPositions"] == 18
+
+
+def test_load_dicom_ge_image_type_scalar(tmp_path):
+    # ImageType present as a scalar string exercises the non-list concat branch.
+    ds = _make_base_dataset()
+    ds.ImageType = "DERIVED"
+    ds.add_new((0x0043, 0x102F), "SS", 2)  # -> 'REAL'
+    path = _write_dataset(ds, tmp_path / "ge_scalar.dcm")
+    result = load_dicom(path)
+    assert result["ImageType"] == ["DERIVED", "REAL"]
+
+
+def test_load_dicom_xa_pe_non_numeric(tmp_path):
+    # Non-integer XA PE value hits the ValueError/TypeError branch and does not
+    # set PhaseEncodingDirectionPositive.
+    ds = _make_base_dataset()
+    ds.add_new((0x0021, 0x111C), "SH", "notanumber")
+    path = _write_dataset(ds, tmp_path / "xa_bad.dcm")
+    result = load_dicom(path)
+    assert "PhaseEncodingDirectionPositive" not in result
+
+
+def test_load_dicom_image_type_scalar_perfusion(tmp_path):
+    # Single-valued ImageType is a scalar string; exercises the scalar
+    # image_type_str branch and ASL scan inference.
+    ds = _make_base_dataset()
+    ds.ImageType = "PERFUSION"
+    path = _write_dataset(ds, tmp_path / "perf.dcm")
+    result = load_dicom(path)
+    assert result["ImageType"] == "PERFUSION"
+
+
+def test_load_dicom_asl_pcasl_params_and_asl_scan(tmp_path, monkeypatch):
+    # has_pcasl_params True + ASL scan -> PCASL (no name hints).
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    ds.ImageType = ["ORIGINAL", "ASL"]
+    path = _write_dataset(ds, tmp_path / "pcasl_param.dcm")
+    monkeypatch.setattr(dio, "_extract_csa_metadata", lambda ds: {"RFGap": 0.001})
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PCASL"
+
+
+def test_load_dicom_asl_pasl_params_and_asl_scan(tmp_path, monkeypatch):
+    # has_pasl_params True + ASL scan -> PASL (no name hints).
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    ds.ImageType = ["ORIGINAL", "PERFUSION"]
+    path = _write_dataset(ds, tmp_path / "pasl_param.dcm")
+    monkeypatch.setattr(dio, "_extract_csa_metadata",
+                        lambda ds: {"BolusDuration": 0.7, "InversionTime": 1.8})
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PASL"
+
+
+def test_load_dicom_iop_wrong_length(tmp_path):
+    # ImageOrientationPatient with unexpected length -> AcquisitionPlane Unknown.
+    ds = _make_base_dataset()
+    ds.add_new((0x0020, 0x0037), "DS", ["1", "0", "0"])  # only 3 values
+    path = _write_dataset(ds, tmp_path / "iop_bad.dcm")
+    result = load_dicom(path)
+    assert result["AcquisitionPlane"] == "Unknown"
+
+
+def test_load_dicom_element_count_uncombined_enhanced(tmp_path):
+    # Enhanced DICOM with a single coil element -> Uncombined via element count.
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "Enhanced"
+    coil = Dataset()
+    coil.ReceiveCoilName = "H"
+    e1 = Dataset(); e1.MultiCoilElementName = "H1"
+    coil.MultiCoilDefinitionSequence = Sequence([e1])
+    shared = Dataset()
+    shared.MRReceiveCoilSequence = Sequence([coil])
+    ds.SharedFunctionalGroupsSequence = Sequence([shared])
+    frame = Dataset()
+    frame.InstanceNumber = "1"
+    ds.PerFrameFunctionalGroupsSequence = Sequence([frame])
+    path = _write_dataset(ds, tmp_path / "enh_single.dcm")
+    result = load_dicom(path)
+    assert all(r["CoilType"] == "Uncombined" for r in result)
+
+
+def test_load_dicom_element_count_zero_no_cointype(tmp_path):
+    # Enhanced DICOM whose coil definition sequence is empty gives an element
+    # count of 0 -> is_combined_coil_from_element_count returns None -> no
+    # CoilType is set (line 709).
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "Enhanced"
+    coil = Dataset()
+    coil.ReceiveCoilName = "H"
+    coil.MultiCoilDefinitionSequence = Sequence([])  # zero elements
+    shared = Dataset()
+    shared.MRReceiveCoilSequence = Sequence([coil])
+    ds.SharedFunctionalGroupsSequence = Sequence([shared])
+    frame = Dataset()
+    frame.InstanceNumber = "1"
+    ds.PerFrameFunctionalGroupsSequence = Sequence([frame])
+    path = _write_dataset(ds, tmp_path / "enh_zero.dcm")
+    result = load_dicom(path)
+    assert all("CoilType" not in r for r in result)
+
+
+def test_load_dicom_philips_trigger_non_numeric(tmp_path):
+    # Non-numeric TriggerDelayTime hits the Philips ValueError/TypeError branch.
+    ds = _make_base_dataset()
+    ds.Manufacturer = "Philips"
+    path = _write_dataset(ds, tmp_path / "phil_bad.dcm")
+
+    real = dio._get_metadata_value
+
+    def fake(metadata, key, default=None):
+        if key == "TriggerDelayTime":
+            return "notnum"
+        return real(metadata, key, default)
+
+    dio._get_metadata_value = fake
+    try:
+        result = load_dicom(path)
+    finally:
+        dio._get_metadata_value = real
+    assert "PostLabelDelay" not in result
+
+
+def test_load_dicom_iop_non_numeric_values(tmp_path):
+    # ImageOrientationPatient with 6 non-numeric values raises inside the
+    # AcquisitionPlane calculation -> Unknown (lines 1054-1056).
+    ds = _make_base_dataset()
+    ds.add_new((0x0020, 0x0037), "DS", ["1", "0", "0", "0", "1", "0"])
+    path = _write_dataset(ds, tmp_path / "iop_ok.dcm")
+
+    # Patch _get_metadata_value used inside load_dicom so IOP returns junk that
+    # cannot be converted to float, exercising the except branch.
+    real = dio._get_metadata_value
+
+    def fake(metadata, key, default=None):
+        if key == "ImageOrientationPatient":
+            return ("a", "b", "c", "d", "e", "f")
+        return real(metadata, key, default)
+
+    orig = dio._get_metadata_value
+    dio._get_metadata_value = fake
+    try:
+        result = load_dicom(path)
+    finally:
+        dio._get_metadata_value = orig
+    assert result["AcquisitionPlane"] == "Unknown"
+
+
+def test_load_dicom_ascconv_pcasl_bad_adfree(tmp_path, monkeypatch):
+    # Non-numeric adFree values exercise the ValueError/TypeError except branches.
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "pcasl_bad.dcm")
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
+        "sAsl": {"ulMode": 1},
+        "tSequenceFileName": "%SiemensSeq%\\ep2d_pcasl",
+        "sWipMemBlock": {"adFree": ["x", "y", "z"]},
+    })
+    result = load_dicom(path)
+    # ASL type still set; bad values silently skipped
+    assert result["ArterialSpinLabelingType"] == "PCASL"
+    assert "LabelOffset" not in result
+
+
+def test_load_dicom_ascconv_pasl_bad_alti(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "pasl_bad.dcm")
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
+        "sAsl": {"ulMode": 2},
+        "tSequenceFileName": "%SiemensSeq%\\ep2d_pasl",
+        "alTI": ["bad", 0.0, "worse"],
+    })
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PASL"
+    assert "BolusDuration" not in result
+
+
+def test_load_dicom_ascconv_vepcasl_bad_values(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "vep_bad.dcm")
+    alFree = ["a"] * 32  # all non-numeric
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {
+        "tSequenceFileName": "%CustomerSeq%\\to_ep2d_VEPCASL",
+        "sWipMemBlock": {"alFree": alFree},
+    })
+    result = load_dicom(path)
+    assert result["ArterialSpinLabelingType"] == "PCASL"
+    assert "TagRFFlipAngle" not in result
+
+
+def test_load_dicom_ascconv_lrepetitions_bad(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "reps_bad.dcm")
+    monkeypatch.setattr(dio, "_extract_ascconv", lambda ds: {"lRepetitions": "notint"})
+    result = load_dicom(path)
+    assert "NumberOfTemporalPositions" not in result
+
+
+def test_load_dicom_labeling_duration_bad_rf(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "ld_bad.dcm")
+    monkeypatch.setattr(dio, "_extract_csa_metadata",
+                        lambda ds: {"NumRFBlocks": "x", "RFGap": "y"})
+    result = load_dicom(path)
+    assert "LabelingDuration" not in result
+
+
+# --------------------------------------------------------------------------
+# _load_one_dicom_path / _load_one_dicom_bytes
+# --------------------------------------------------------------------------
+
+def test_load_one_dicom_path(tmp_path):
+    ds = _make_base_dataset()
+    ds.InstanceNumber = "5"
+    path = _write_dataset(ds, tmp_path / "one.dcm")
+    result = _load_one_dicom_path(path, skip_pixel_data=True)
+    assert result["DICOM_Path"] == path
+    assert result["InstanceNumber"] == 5
+
+
+def test_load_one_dicom_path_missing_modality(tmp_path):
+    ds = _make_base_dataset()
+    del ds.Modality
+    path = _write_dataset(ds, tmp_path / "nomod.dcm")
+    with pytest.raises(ValueError, match="Modality"):
+        _load_one_dicom_path(path, skip_pixel_data=True)
+
+
+def test_load_one_dicom_bytes(tmp_path):
+    ds = _make_base_dataset()
+    ds.InstanceNumber = "9"
+    path = _write_dataset(ds, tmp_path / "b.dcm")
+    with open(path, "rb") as f:
+        content = f.read()
+    result = _load_one_dicom_bytes("key1", content, skip_pixel_data=True)
+    assert result["DICOM_Path"] == "key1"
+    assert result["InstanceNumber"] == 9
+
+
+def test_load_one_dicom_bytes_missing_modality(tmp_path):
+    ds = _make_base_dataset()
+    del ds.Modality
+    path = _write_dataset(ds, tmp_path / "nomodb.dcm")
+    with open(path, "rb") as f:
+        content = f.read()
+    with pytest.raises(ValueError, match="Modality"):
+        _load_one_dicom_bytes("k", content, skip_pixel_data=True)
+
+
+def test_load_one_dicom_path_enhanced(tmp_path):
+    ds = _make_enhanced_dataset()
+    path = _write_dataset(ds, tmp_path / "enh_path.dcm")
+    result = _load_one_dicom_path(path, skip_pixel_data=True)
+    assert isinstance(result, list)
+    for item in result:
+        assert item["DICOM_Path"] == path
+
+
+def test_load_one_dicom_bytes_enhanced(tmp_path):
+    ds = _make_enhanced_dataset()
+    path = _write_dataset(ds, tmp_path / "enh_bytes.dcm")
+    with open(path, "rb") as f:
+        content = f.read()
+    result = _load_one_dicom_bytes("ek", content, skip_pixel_data=True)
+    assert isinstance(result, list)
+    for item in result:
+        assert item["DICOM_Path"] == "ek"
+
+
+def test_load_dicom_csa_non_dict_warns(tmp_path, monkeypatch):
+    # CSA metadata returned as a non-dict truthy value triggers a warning and is
+    # not merged (line 645).
+    ds = _make_base_dataset()
+    ds.Manufacturer = "SIEMENS"
+    path = _write_dataset(ds, tmp_path / "csa_bad.dcm")
+    monkeypatch.setattr(dio, "_extract_csa_metadata", lambda ds: ["not", "a", "dict"])
+    result = load_dicom(path)
+    assert result["PatientName"] == "Test^Patient"
+
+
+def test_load_dicom_inferred_non_dict_warns(tmp_path, monkeypatch):
+    ds = _make_base_dataset()
+    path = _write_dataset(ds, tmp_path / "inf_bad.dcm")
+    monkeypatch.setattr(dio, "_extract_inferred_metadata", lambda ds: ["bad"])
+    result = load_dicom(path)
+    assert result["PatientName"] == "Test^Patient"
+
+
+# --------------------------------------------------------------------------
+# Session loaders
+# --------------------------------------------------------------------------
+
+def test_load_dicom_session_from_dir(tmp_path):
+    for i in range(3):
+        ds = _make_base_dataset()
+        ds.InstanceNumber = str(i + 1)
+        ds.SeriesDescription = "T1w"
+        _write_dataset(ds, tmp_path / f"f{i}.dcm")
+    df = load_dicom_session(session_dir=str(tmp_path))
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 3
+
+
+def test_load_dicom_session_from_bytes(tmp_path):
+    ds = _make_base_dataset()
+    ds.SeriesDescription = "T1w"
+    path = _write_dataset(ds, tmp_path / "x.dcm")
+    with open(path, "rb") as f:
+        content = f.read()
+    df = load_dicom_session(dicom_bytes={"x.dcm": content})
+    assert len(df) == 1
+
+
+def test_async_load_dicom_session_parallel(tmp_path):
+    for i in range(2):
+        ds = _make_base_dataset()
+        ds.InstanceNumber = str(i + 1)
+        _write_dataset(ds, tmp_path / f"p{i}.dcm")
+    df = asyncio.run(async_load_dicom_session(session_dir=str(tmp_path), parallel_workers=2))
+    assert len(df) == 2
+
+
+def test_async_load_dicom_session_requires_source():
+    with pytest.raises(ValueError, match="Either session_dir or dicom_bytes"):
+        asyncio.run(async_load_dicom_session())
+
+
+def test_load_dicom_session_enhanced_flatten(tmp_path):
+    # Enhanced DICOM files return lists of frame dicts, which the session loader
+    # must flatten into individual rows (line 1272).
+    ds = _make_enhanced_dataset()
+    _write_dataset(ds, tmp_path / "enh_session.dcm")
+    df = load_dicom_session(session_dir=str(tmp_path))
+    # Two frames -> two rows
+    assert len(df) == 2
+
+
+def test_load_dicom_session_show_progress(tmp_path):
+    ds = _make_base_dataset()
+    _write_dataset(ds, tmp_path / "prog.dcm")
+    df = load_dicom_session(session_dir=str(tmp_path), show_progress=True)
+    assert len(df) == 1
+
+
+# --------------------------------------------------------------------------
+# load_nifti_session
+# --------------------------------------------------------------------------
+
+def _write_nifti(path, shape=(2, 2, 2)):
+    import nibabel as nib
+    data = np.zeros(shape, dtype=np.int16)
+    nib.save(nib.Nifti1Image(data, np.eye(4)), str(path))
+
+
+def test_load_nifti_session_basic(tmp_path):
+    nii = tmp_path / "sub-01_task-rest_bold.nii"
+    _write_nifti(nii)
+    df = load_nifti_session(session_dir=str(tmp_path), acquisition_fields=None)
+    assert "NIfTI_Path" in df.columns
+    # BIDS tag extraction
+    vals = df.reset_index(drop=True).iloc[0].to_dict()
+    assert vals["sub"] == "01"
+    assert vals["suffix"] == "bold"
+
+
+def test_load_nifti_session_with_json(tmp_path):
+    nii = tmp_path / "sub-02_T1w.nii"
+    _write_nifti(nii)
+    json_path = tmp_path / "sub-02_T1w.json"
+    json_path.write_text('{"EchoTime": 0.003}')
+    df = load_nifti_session(session_dir=str(tmp_path), acquisition_fields=None)
+    row = df.reset_index(drop=True).iloc[0].to_dict()
+    assert row["EchoTime"] == 0.003
+    assert row["JSON_Path"] == str(json_path)
+
+
+def test_load_nifti_session_4d(tmp_path):
+    nii = tmp_path / "sub-03_bold.nii"
+    _write_nifti(nii, shape=(2, 2, 2, 3))
+    df = load_nifti_session(session_dir=str(tmp_path), acquisition_fields=None)
+    # 4D -> one row per volume
+    assert len(df) == 3
+    vol_indices = sorted(df["Volume_Index"].tolist())
+    assert vol_indices == [0, 1, 2]
+
+
+def test_load_nifti_session_no_files_raises(tmp_path):
+    with pytest.raises(ValueError, match="No NIfTI files found"):
+        load_nifti_session(session_dir=str(tmp_path))
+
+
+def test_load_nifti_session_unavailable_acq_field(tmp_path):
+    nii = tmp_path / "plain.nii"
+    _write_nifti(nii)
+    # acquisition field doesn't exist as a column -> no grouping, no error
+    df = load_nifti_session(session_dir=str(tmp_path), acquisition_fields=["NotAColumn"])
+    assert len(df) == 1
+
+
+def test_load_nifti_session_groupby(tmp_path):
+    # Two files with a shared BIDS 'sub' key exercise the groupby branch.
+    _write_nifti(tmp_path / "sub-01_T1w.nii")
+    _write_nifti(tmp_path / "sub-02_T1w.nii")
+    df = load_nifti_session(session_dir=str(tmp_path), acquisition_fields=["sub"])
+    assert len(df) == 2
+
+
+def test_load_nifti_session_show_progress(tmp_path):
+    _write_nifti(tmp_path / "sub-01_T1w.nii")
+    df = load_nifti_session(session_dir=str(tmp_path), acquisition_fields=None,
+                            show_progress=True)
+    assert len(df) == 1

--- a/dicompare/tests/test_examcard_coverage.py
+++ b/dicompare/tests/test_examcard_coverage.py
@@ -1,0 +1,602 @@
+"""
+Additional coverage tests for dicompare/io/examcard.py.
+
+These tests exercise:
+  * The real Philips ExamCard fixtures (DUAL_ECHO_EPI, SSdense) through the
+    public loaders in both flat and schema formats.
+  * The XML navigation helpers with small synthetic SOAP documents.
+  * The binary parameter parsing helpers with hand-built byte buffers that hit
+    every parameter type (float/int/string/enum) and each validation branch.
+  * The derived-field / mapping / schema-format branches that the existing
+    test_examcard.py does not reach.
+
+Only this file is added; source is not modified.
+"""
+
+import base64
+import shutil
+import struct
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from dicompare.io import examcard as ec
+from dicompare.io.examcard import (
+    load_examcard_file,
+    load_examcard_file_schema_format,
+    apply_examcard_to_dicom_mapping,
+    _parse_examcard,
+    _parse_examcard_all_scans,
+    _parse_parameter_data,
+    _get_a_param,
+    _get_param_value,
+    _calculate_derived_fields,
+    _clean_tag,
+    _get_attrib_value,
+    _get_nodes_by_tag,
+    _get_node_by_attrib_value,
+    _get_child_by_tag,
+    _get_child_thru_ref,
+    _get_child_name,
+    _get_item_content,
+    _get_info_for_node,
+    _extract_series_parameters,
+    _generate_series_combinations,
+    _convert_to_schema_format,
+    _sort_output_fields,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DUAL_ECHO = REPO_ROOT / "DUAL_ECHO_EPI.ExamCard"
+SSDENSE = REPO_ROOT / "SSdense_July2024.ExamCard"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building synthetic binary parameter blocks
+# ---------------------------------------------------------------------------
+
+_HEADER = b"\x00" * 32  # pos0 offset used by _get_a_param
+
+
+def _make_param(name, typ, num, off1_rel, off2_rel):
+    """Build a single 50-byte parameter entry matching the parser's layout."""
+    nb = name.encode("utf-8")
+    block = nb + b"\x00" * (34 - len(nb))
+    block += struct.pack("<I", typ)       # bytes 34-37: type
+    block += struct.pack("<I", num)       # bytes 38-41: count
+    block += struct.pack("<I", off1_rel)  # bytes 42-45: off1 (relative)
+    block += struct.pack("<I", off2_rel)  # bytes 46-49: off2 (relative)
+    assert len(block) == 50
+    return block
+
+
+class _TextNode:
+    """Minimal stand-in for an XML node carrying base64 text."""
+
+    def __init__(self, text):
+        self.text = text
+
+
+# ===========================================================================
+# Real fixture tests through the public loaders
+# ===========================================================================
+
+class TestRealFixturesFlat:
+    def test_dual_echo_flat(self):
+        result = load_examcard_file(str(DUAL_ECHO))
+        assert result["Manufacturer"] == "Philips"
+        assert result["ProtocolName"] == "GE-SE EPI 2Sh 1Sl"
+        assert result["ScanningSequence"] == "SE"
+        # Dual echo -> list of two echo times
+        assert result["EchoTime"] == [30.0, 70.0]
+        assert result["ExamCard_FileName"] == "DUAL_ECHO_EPI.ExamCard"
+        assert result["ExamCard_Path"] == str(DUAL_ECHO)
+        # A whitelisted Philips-specific parameter should be surfaced.
+        assert result["Philips_ACQ_echoes"] == 2
+
+    def test_ssdense_flat(self):
+        result = load_examcard_file(str(SSDENSE))
+        assert result["Manufacturer"] == "Philips"
+        assert result["ProtocolName"]  # first non-General scan
+        assert result["ExamCard_FileName"] == "SSdense_July2024.ExamCard"
+
+    def test_copy_into_tmp_path(self, tmp_path):
+        dest = tmp_path / "copy.ExamCard"
+        shutil.copy(DUAL_ECHO, dest)
+        result = load_examcard_file(str(dest))
+        assert result["Manufacturer"] == "Philips"
+
+
+class TestRealFixturesSchema:
+    def test_dual_echo_schema(self):
+        scans = load_examcard_file_schema_format(str(DUAL_ECHO))
+        assert len(scans) == 2
+        first = scans[0]
+        assert set(first.keys()) == {"acquisition_info", "fields", "series"}
+        info = first["acquisition_info"]
+        assert info["source_type"] == "examcard"
+        assert info["protocol_name"] == "GE-SE EPI 2Sh 1Sl"
+        assert info["examcard_filename"] == "DUAL_ECHO_EPI.ExamCard"
+        # Series are generated from the two echo times.
+        assert len(first["series"]) == 2
+        assert first["series"][0]["fields"][0]["field"] == "EchoTime"
+        echo_values = [s["fields"][0]["value"] for s in first["series"]]
+        assert echo_values == [30.0, 70.0]
+        # EchoTime is series-varying so it must NOT be an acquisition-level field.
+        acq_field_names = {f["field"] for f in first["fields"]}
+        assert "EchoTime" not in acq_field_names
+        assert "Manufacturer" in acq_field_names
+
+    def test_ssdense_schema(self):
+        scans = load_examcard_file_schema_format(str(SSDENSE))
+        assert len(scans) == 14
+        names = [s["acquisition_info"]["protocol_name"] for s in scans]
+        assert "AnatBrain_T1W3D" in names
+        # Single-echo scans produce no series entries.
+        for s in scans:
+            for f in s["fields"]:
+                assert f["value"] not in (None, "")
+
+
+class TestFileErrors:
+    def test_load_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            load_examcard_file("/no/such/file.ExamCard")
+
+    def test_load_schema_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            load_examcard_file_schema_format("/no/such/file.ExamCard")
+
+    def test_parse_all_scans_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            _parse_examcard_all_scans("/no/such/file.ExamCard")
+
+    def test_parse_malformed_xml_raises(self, tmp_path):
+        bad = tmp_path / "bad.ExamCard"
+        bad.write_text("<SOAP-ENV:Envelope><unclosed>")
+        with pytest.raises(RuntimeError):
+            _parse_examcard_all_scans(str(bad))
+
+    def test_parse_examcard_no_scans_returns_empty(self, tmp_path):
+        # Valid XML with no ExecutionStep / ExamCard nodes -> {} from
+        # _parse_examcard (line: "return {}").
+        f = tmp_path / "empty.ExamCard"
+        f.write_text("<root><child/></root>")
+        assert _parse_examcard(str(f)) == {}
+
+    def test_trailing_garbage_after_envelope(self, tmp_path):
+        # Exercise the closing-tag truncation path with well-formed content.
+        f = tmp_path / "trail.ExamCard"
+        f.write_text(
+            "<SOAP-ENV:Envelope xmlns:SOAP-ENV='urn:x'>"
+            "<body/></SOAP-ENV:Envelope>GARBAGE_AFTER_TAG\x00\x01"
+        )
+        result = _parse_examcard_all_scans(str(f))
+        assert result == {}  # no ExamCard/ExecutionStep nodes
+
+
+# ===========================================================================
+# XML helper functions
+# ===========================================================================
+
+class TestXmlHelpers:
+    def test_clean_tag(self):
+        assert _clean_tag("{urn:ns}ExamCard") == "ExamCard"
+        assert _clean_tag("plain") == "plain"
+
+    def test_get_attrib_value(self):
+        node = ET.fromstring('<n xmlns:x="urn:x" x:href="#abc" other="1"/>')
+        assert _get_attrib_value(node, "href") == "#abc"
+        assert _get_attrib_value(node, "missing") is None
+
+    def test_get_nodes_by_tag(self):
+        root = ET.fromstring("<a><b/><c><b/></c></a>")
+        assert len(_get_nodes_by_tag(root, "b")) == 2
+
+    def test_get_node_by_attrib_value(self):
+        root = ET.fromstring('<a><b id="x1"/><c id="x2"/></a>')
+        found = _get_node_by_attrib_value(root, "id", "x2")
+        assert found is not None and _clean_tag(found.tag) == "c"
+        # No match -> None
+        assert _get_node_by_attrib_value(root, "id", "nope") is None
+
+    def test_get_child_by_tag(self):
+        parent = ET.fromstring("<p><a/><b/></p>")
+        assert _clean_tag(_get_child_by_tag(parent, "b").tag) == "b"
+        assert _get_child_by_tag(parent, "z") is None
+
+    def test_get_child_thru_ref_missing_child(self):
+        parent = ET.fromstring("<p><a/></p>")
+        assert _get_child_thru_ref(parent, parent, "missing") is None
+
+    def test_get_child_thru_ref_no_href_returns_child(self):
+        parent = ET.fromstring("<p><target>value</target></p>")
+        child = _get_child_thru_ref(parent, parent, "target")
+        assert child is not None
+        assert child.text == "value"
+
+    def test_get_child_thru_ref_follows_href(self):
+        root = ET.fromstring(
+            '<root xmlns:x="urn:x">'
+            '<parent><target x:href="#ref1"/></parent>'
+            '<data id="ref1"><v>42</v></data>'
+            "</root>"
+        )
+        parent = _get_child_by_tag(root, "parent")
+        resolved = _get_child_thru_ref(root, parent, "target")
+        assert resolved is not None
+        assert _clean_tag(resolved.tag) == "data"
+
+    def test_get_child_name(self):
+        node = ET.fromstring("<n><name>  Hello  </name></n>")
+        assert _get_child_name(node) == "Hello"
+        assert _get_child_name(ET.fromstring("<n/>")) == ""
+
+    def test_get_item_content(self):
+        node = ET.fromstring("<n><a> x </a><b/><c>y</c></n>")
+        assert _get_item_content(node) == {"a": "x", "c": "y"}
+
+    def test_get_info_for_node_text_and_ref(self):
+        root = ET.fromstring(
+            '<root xmlns:x="urn:x">'
+            '<node><plain> hi </plain><reffed x:href="#r"/></node>'
+            '<blob id="r"><k>v</k></blob>'
+            "</root>"
+        )
+        node = _get_child_by_tag(root, "node")
+        info = _get_info_for_node(node, root)
+        assert info["plain"] == "hi"
+        assert info["reffed"] == {"k": "v"}
+
+    def test_get_info_for_node_dangling_ref(self):
+        # href that resolves to nothing -> key omitted.
+        root = ET.fromstring(
+            '<root xmlns:x="urn:x"><node><reffed x:href="#missing"/></node></root>'
+        )
+        node = _get_child_by_tag(root, "node")
+        assert _get_info_for_node(node, root) == {}
+
+
+# ===========================================================================
+# Binary parameter parsing
+# ===========================================================================
+
+class TestParamValue:
+    def test_float_multi(self):
+        data = struct.pack("<f", 1.5) + struct.pack("<f", 2.5)
+        val, enum = _get_param_value(0, 2, 0, 0, data)
+        assert val == [1.5, 2.5]
+        assert enum is None
+
+    def test_int_single(self):
+        data = struct.pack("<i", 7)
+        val, _ = _get_param_value(1, 1, 0, 0, data)
+        assert val == 7
+
+    def test_string(self):
+        data = b"\x00" * 40 + b"HELLO\x00" + b"\x00" * 100
+        val, _ = _get_param_value(2, 1, 0, 40, data)
+        assert val == "HELLO"
+
+    def test_enum(self):
+        data = b"A,B,C\x00" + struct.pack("<i", 2)
+        val, enum = _get_param_value(4, 1, 0, 6, data)
+        assert val == 2
+        assert enum == ("A,B,C", ["A", "B", "C"])
+
+    def test_no_values_returns_none(self):
+        val, enum = _get_param_value(0, 1, 0, 0, b"")
+        assert val is None and enum is None
+
+    def test_exception_path_swallowed(self):
+        # off2 = None triggers a TypeError inside the try/except -> returns None.
+        val, enum = _get_param_value(0, 1, 0, None, b"\x00\x00\x00\x00")
+        assert val is None and enum is None
+
+
+class TestGetAParam:
+    def test_int_param(self):
+        data = _HEADER + _make_param("EX_ACQ_flip_angle", 1, 1, 0, 4) + struct.pack("<i", 45)
+        name, val, enum = _get_a_param(data, 0)
+        assert name == "EX_ACQ_flip_angle"
+        assert val == 45
+        assert enum is None
+
+    def test_enum_param_with_map(self):
+        data = (
+            _HEADER
+            + _make_param("EX_ACQ_scan_mode", 4, 1, 8, 13)
+            + b"AA,BB,CC\x00"
+            + struct.pack("<i", 1)
+        )
+        name, val, enum = _get_a_param(data, 0)
+        assert name == "EX_ACQ_scan_mode"
+        assert val == 1
+        assert enum[1] == ["AA", "BB", "CC"]
+
+    def test_end_beyond_buffer(self):
+        assert _get_a_param(b"\x00" * 32, 0) == (None, None, None)
+
+    def test_name_too_short(self):
+        data = _HEADER + _make_param("EX", 1, 1, 0, 0)
+        assert _get_a_param(data, 0) == (None, None, None)
+
+    def test_name_without_underscore(self):
+        data = _HEADER + _make_param("ABCDEF", 1, 1, 0, 0)
+        assert _get_a_param(data, 0) == (None, None, None)
+
+    def test_type_out_of_range(self):
+        data = _HEADER + _make_param("EX_ACQ_x", 9, 1, 0, 0)
+        assert _get_a_param(data, 0) == (None, None, None)
+
+
+class TestParseParameterData:
+    def test_none_node(self):
+        assert _parse_parameter_data(None) == ({}, {})
+
+    def test_none_text(self):
+        assert _parse_parameter_data(_TextNode(None)) == ({}, {})
+
+    def test_invalid_base64(self):
+        assert _parse_parameter_data(_TextNode("!!!not base64!!!")) == ({}, {})
+
+    def test_roundtrip_int_and_enum(self):
+        data = (
+            _HEADER
+            + _make_param("EX_ACQ_scan_mode", 4, 1, 8, 13)
+            + b"AA,BB,CC\x00"
+            + struct.pack("<i", 2)
+        )
+        node = _TextNode(base64.b64encode(data).decode())
+        params, enum_map = _parse_parameter_data(node)
+        assert params["EX_ACQ_scan_mode"] == 2
+        assert enum_map["EX_ACQ_scan_mode"] == ["AA", "BB", "CC"]
+
+    def test_stops_at_first_invalid(self):
+        # A valid param followed by junk stops iteration at the junk.
+        good = _make_param("EX_ACQ_flip_angle", 1, 1, 0, 4)
+        data = _HEADER + good + struct.pack("<i", 12)
+        node = _TextNode(base64.b64encode(data).decode())
+        params, _ = _parse_parameter_data(node)
+        assert params == {"EX_ACQ_flip_angle": 12}
+
+
+# ===========================================================================
+# Mapping / derived-field branches not covered by test_examcard.py
+# ===========================================================================
+
+class TestMappingBranches:
+    def test_gex_and_if_name_cleaning(self):
+        # USEFUL_PHILIPS_PARAMETERS is a whitelist, so add temp entries to
+        # exercise the GEX_/IF_ prefix-stripping branches, then restore.
+        added = {"GEX_custom_thing", "IF_custom_thing"}
+        original = set(ec.USEFUL_PHILIPS_PARAMETERS)
+        ec.USEFUL_PHILIPS_PARAMETERS.update(added)
+        try:
+            scan_data = {
+                "name": "T",
+                "parameters": {"GEX_custom_thing": 5, "IF_custom_thing": 9},
+                "enum_map": {},
+            }
+            result = apply_examcard_to_dicom_mapping(scan_data)
+            assert result["Philips_custom_thing"] in (5, 9)
+            # Both cleaned to the same key; last write wins but both branches ran.
+            assert "Philips_custom_thing" in result
+        finally:
+            ec.USEFUL_PHILIPS_PARAMETERS.clear()
+            ec.USEFUL_PHILIPS_PARAMETERS.update(original)
+
+    def test_whitelisted_enum_translation(self):
+        # Unmapped-but-whitelisted param that is an int + has enum_map entry.
+        scan_data = {
+            "name": "T",
+            "parameters": {"EX_ACQ_gradient_mode": 1},
+            "enum_map": {"EX_ACQ_gradient_mode": ["DEFAULT", "FAST"]},
+        }
+        result = apply_examcard_to_dicom_mapping(scan_data)
+        assert result["Philips_ACQ_gradient_mode"] == "FAST"
+
+    def test_reconstruction_diameter(self):
+        scan_data = {
+            "name": "T",
+            "parameters": {
+                "EX_PROC_recon_resolution": 256,
+                "EX_PROC_recon_voxel_size_m": 1.0,
+                "EX_PROC_recon_voxel_size_p": 1.0,
+            },
+            "enum_map": {},
+        }
+        result = apply_examcard_to_dicom_mapping(scan_data)
+        assert result["ReconstructionDiameter"] == 256.0
+
+    def test_tr_te_from_combined_string_when_missing(self):
+        dicom_fields = {}
+        params = {"IF_act_rep_time_echo_time": "9.8 / 4.6"}
+        _calculate_derived_fields(dicom_fields, params)
+        assert dicom_fields["RepetitionTime"] == 9.8
+        assert dicom_fields["EchoTime"] == 4.6
+
+    def test_te_only_from_combined_string(self):
+        # RepetitionTime already present -> only TE branch parses.
+        dicom_fields = {"RepetitionTime": 100.0}
+        params = {"IF_act_rep_time_echo_time": "100.0 / 3.2"}
+        _calculate_derived_fields(dicom_fields, params)
+        assert dicom_fields["RepetitionTime"] == 100.0
+        assert dicom_fields["EchoTime"] == 3.2
+
+    def test_te_combined_string_bad_second_part(self):
+        dicom_fields = {"RepetitionTime": 100.0}
+        params = {"IF_act_rep_time_echo_time": "100.0 / notanumber"}
+        _calculate_derived_fields(dicom_fields, params)
+        assert "EchoTime" not in dicom_fields
+
+    def test_acquisition_duration_value_error(self):
+        dicom_fields = {}
+        params = {"IF_str_total_scan_time": "bad:xx"}
+        _calculate_derived_fields(dicom_fields, params)
+        assert "AcquisitionDuration" not in dicom_fields
+
+    def test_number_of_slices_float(self):
+        dicom_fields = {}
+        params = {"EX_GEO_stacks_slices": 30.0}
+        _calculate_derived_fields(dicom_fields, params)
+        assert dicom_fields["NumberOfSlices"] == 30
+
+    def test_tr_combined_string_bad_first_part(self):
+        # RepetitionTime missing and first part unparseable -> ValueError swallowed.
+        dicom_fields = {}
+        params = {"IF_act_rep_time_echo_time": "notanumber / 4.6"}
+        _calculate_derived_fields(dicom_fields, params)
+        assert "RepetitionTime" not in dicom_fields
+
+    def test_sort_output_other_dicom_field(self):
+        # A non-Philips DICOM field that is not in DICOM_FIELD_ORDER falls into
+        # the "other_dicom" bucket (sorted alphabetically after ordered fields).
+        fields = {
+            "SeriesDescription": "T",   # in DICOM_FIELD_ORDER
+            "ZCustomTag": 1,            # not in order, not Philips_
+            "ACustomTag": 2,            # not in order, not Philips_
+            "Philips_z": 3,
+        }
+        result = _sort_output_fields(fields)
+        keys = list(result.keys())
+        assert keys.index("SeriesDescription") < keys.index("ACustomTag")
+        assert keys.index("ACustomTag") < keys.index("ZCustomTag")  # alphabetical
+        assert keys.index("ZCustomTag") < keys.index("Philips_z")
+
+
+# ===========================================================================
+# Schema-format helpers
+# ===========================================================================
+
+class TestSchemaHelpers:
+    def test_extract_series_parameters_dual_echo(self):
+        raw = {"parameters": {"EX_ACQ_first_echo_time": 10.0, "EX_ACQ_second_echo_time": 20.0}}
+        series = _extract_series_parameters({}, raw)
+        assert series == {"EchoTime": [10.0, 20.0]}
+
+    def test_extract_series_parameters_single_echo(self):
+        raw = {"parameters": {"EX_ACQ_first_echo_time": 10.0, "EX_ACQ_second_echo_time": 0}}
+        assert _extract_series_parameters({}, raw) == {}
+
+    def test_generate_series_combinations_empty(self):
+        assert _generate_series_combinations({}) == []
+
+    def test_generate_series_combinations(self):
+        series = _generate_series_combinations({"EchoTime": [5.0, 10.0]})
+        assert len(series) == 2
+        assert series[0] == {"name": "Series 01", "fields": [{"field": "EchoTime", "value": 5.0}]}
+
+    def test_convert_to_schema_skips_metadata_and_empty(self):
+        dicom_fields = {
+            "Manufacturer": "Philips",
+            "ExamCard_Path": "x",
+            "ExamCard_FileName": "x",
+            "ScanName": "skip-me",
+            "EmptyField": "",
+            "NoneField": None,
+            "EchoTime": [10.0, 20.0],
+        }
+        raw = {"parameters": {"EX_ACQ_first_echo_time": 10.0, "EX_ACQ_second_echo_time": 20.0}}
+        schema = _convert_to_schema_format(dicom_fields, raw, "MyScan", "/tmp/my.ExamCard")
+        field_names = {f["field"] for f in schema["fields"]}
+        assert "Manufacturer" in field_names
+        # Metadata / empty / series-varying fields excluded from acquisition fields.
+        for excluded in ["ExamCard_Path", "ExamCard_FileName", "ScanName",
+                         "EmptyField", "NoneField", "EchoTime"]:
+            assert excluded not in field_names
+        # EchoTime becomes a series-varying param.
+        assert len(schema["series"]) == 2
+        assert schema["acquisition_info"]["protocol_name"] == "MyScan"
+
+
+# ===========================================================================
+# _parse_examcard_all_scans branch coverage via synthetic SOAP document
+# ===========================================================================
+
+def _build_soap(scan_xml):
+    return (
+        "<SOAP-ENV:Envelope xmlns:SOAP-ENV='urn:soap' xmlns:x='urn:x'>"
+        "<ExamCard><methodDescription>General card</methodDescription></ExamCard>"
+        f"{scan_xml}"
+        "</SOAP-ENV:Envelope>"
+    )
+
+
+class TestParseAllScansSynthetic:
+    def test_step_missing_single_scan_skipped(self, tmp_path):
+        # ExecutionStep whose singleScan cannot be resolved -> continue.
+        soap = _build_soap("<ExecutionStep><nothing/></ExecutionStep>")
+        f = tmp_path / "s.ExamCard"
+        f.write_text(soap)
+        result = _parse_examcard_all_scans(str(f))
+        assert "General" in result
+        # Only General should be present (scan was skipped).
+        assert list(result.keys()) == ["General"]
+
+    def test_step_missing_scan_procedure_skipped(self, tmp_path):
+        soap = _build_soap(
+            "<ExecutionStep><singleScan><name>S1</name></singleScan></ExecutionStep>"
+        )
+        f = tmp_path / "s.ExamCard"
+        f.write_text(soap)
+        result = _parse_examcard_all_scans(str(f))
+        assert list(result.keys()) == ["General"]
+
+    def test_scan_name_fallback_to_index(self, tmp_path):
+        # singleScan + scanProcedure present but no name anywhere -> Scan_1.
+        soap = _build_soap(
+            "<ExecutionStep><singleScan>"
+            "<scanProcedure><parameterData></parameterData></scanProcedure>"
+            "</singleScan></ExecutionStep>"
+        )
+        f = tmp_path / "s.ExamCard"
+        f.write_text(soap)
+        result = _parse_examcard_all_scans(str(f))
+        assert "Scan_1" in result
+        assert result["Scan_1"]["name"] == "Scan_1"
+
+    def test_scan_name_from_scan_procedure(self, tmp_path):
+        # No name on singleScan, name present on scanProcedure.
+        soap = _build_soap(
+            "<ExecutionStep><singleScan>"
+            "<scanProcedure><name>ProcName</name>"
+            "<parameterData></parameterData></scanProcedure>"
+            "</singleScan></ExecutionStep>"
+        )
+        f = tmp_path / "s.ExamCard"
+        f.write_text(soap)
+        result = _parse_examcard_all_scans(str(f))
+        assert "ProcName" in result
+
+    def test_scan_loop_exception_skipped(self, tmp_path, monkeypatch):
+        # Force an exception while processing a scan; the loop should swallow it
+        # (lines 461-463 "except Exception: continue") and still return General.
+        soap = _build_soap(
+            "<ExecutionStep><singleScan><name>S1</name>"
+            "<scanProcedure><parameterData></parameterData></scanProcedure>"
+            "</singleScan></ExecutionStep>"
+        )
+        f = tmp_path / "s.ExamCard"
+        f.write_text(soap)
+
+        def boom(node):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(ec, "_parse_parameter_data", boom)
+        result = _parse_examcard_all_scans(str(f))
+        assert list(result.keys()) == ["General"]
+
+    def test_scan_properties_merged(self, tmp_path):
+        soap = _build_soap(
+            "<ExecutionStep><singleScan><name>S1</name>"
+            "<scanProcedure><parameterData></parameterData></scanProcedure>"
+            "<scanProperties><foo>bar</foo></scanProperties>"
+            "</singleScan></ExecutionStep>"
+        )
+        f = tmp_path / "s.ExamCard"
+        f.write_text(soap)
+        result = _parse_examcard_all_scans(str(f))
+        assert result["S1"]["foo"] == "bar"

--- a/dicompare/tests/test_examcard_coverage.py
+++ b/dicompare/tests/test_examcard_coverage.py
@@ -445,7 +445,7 @@ class TestMappingBranches:
         assert dicom_fields["NumberOfSlices"] == 30
 
     def test_tr_combined_string_bad_first_part(self):
-        # RepetitionTime missing and first part unparseable -> ValueError swallowed.
+        # RepetitionTime missing and first part not parsable -> ValueError swallowed.
         dicom_fields = {}
         params = {"IF_act_rep_time_echo_time": "notanumber / 4.6"}
         _calculate_derived_fields(dicom_fields, params)

--- a/dicompare/tests/test_pro_coverage.py
+++ b/dicompare/tests/test_pro_coverage.py
@@ -1,0 +1,1194 @@
+"""
+Additional coverage tests for dicompare/io/pro.py.
+
+These tests target the pure helper functions (sequence/image type detection,
+version/partial-Fourier/b-value decoding, physio detection), the schema-format
+generation helpers, and the .exar1 archive path. They use small synthetic
+pro_data dicts to hit specific branches and synthesize a tiny SQLite .exar1
+archive so the DB-read code path is exercised without a real fixture.
+
+They deliberately avoid duplicating what test_pro_files.py already covers.
+"""
+
+import sqlite3
+import zlib
+import json
+import hashlib
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from dicompare.io import pro as pro_mod
+from dicompare.io.pro import (
+    apply_pro_to_dicom_mapping,
+    calculate_other_dicom_fields,
+    extract_nested_value,
+    _decode_siemens_version,
+    _decode_partial_fourier,
+    _nominal_field_strength,
+    _extract_unique_b_values,
+    _decode_sequence_type,
+    _physio_signal_method,
+    _detect_scan_options,
+    _detect_image_type,
+    _detect_sequence_variant,
+    _determine_image_types_for_series,
+    _extract_series_parameters,
+    _generate_series_combinations,
+    _classify_fields,
+    _convert_flat_to_schema_format,
+    load_pro_file,
+    load_pro_file_schema_format,
+    load_pro_session,
+    load_pro_session_simple,
+    _decompress_raw_deflate,
+    _extract_protocol_text_from_xprotocol,
+    _describe_exar_contents,
+    _extract_protocols_from_exar,
+    load_exar_file,
+    load_exar_file_schema_format,
+    load_exar_session,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "pro_files"
+
+
+# ---------------------------------------------------------------------------
+# extract_nested_value
+# ---------------------------------------------------------------------------
+
+class TestExtractNestedValue:
+    def test_simple_and_nested(self):
+        data = {"a": {"b": {"c": 5}}}
+        assert extract_nested_value(data, "a.b.c") == 5
+
+    def test_list_index(self):
+        data = {"a": [{"x": 1}, {"x": 2}]}
+        assert extract_nested_value(data, "a.1.x") == 2
+
+    def test_missing_key_returns_none(self):
+        assert extract_nested_value({"a": 1}, "a.b") is None
+        assert extract_nested_value({"a": 1}, "z") is None
+
+    def test_list_index_out_of_range(self):
+        assert extract_nested_value({"a": [1]}, "a.5") is None
+
+    def test_index_into_non_list(self):
+        assert extract_nested_value({"a": {"b": 1}}, "a.0") is None
+
+    def test_none_current_short_circuits(self):
+        assert extract_nested_value({"a": None}, "a.b.c") is None
+
+
+# ---------------------------------------------------------------------------
+# _decode_siemens_version
+# ---------------------------------------------------------------------------
+
+class TestDecodeSiemensVersion:
+    def test_decimal_exact_match(self):
+        assert _decode_siemens_version(21710006) == "VB17A"
+        assert _decode_siemens_version(51130001) == "VE12U"
+
+    def test_hex_exact_match(self):
+        assert _decode_siemens_version(0xbee332) == "VA25A"
+
+    def test_string_hex_input(self):
+        assert _decode_siemens_version("0xbee332") == "VA25A"
+
+    def test_string_decimal_input(self):
+        assert _decode_siemens_version("21710006") == "VB17A"
+
+    def test_infer_newest(self):
+        assert _decode_siemens_version(70000000) == "VE12U+"
+
+    def test_infer_ve12u_range(self):
+        assert _decode_siemens_version(51290000) == "VE12U"
+
+    def test_infer_ve11x_range(self):
+        assert _decode_siemens_version(51000000) == "VE11x"
+
+    def test_infer_vd_range(self):
+        assert _decode_siemens_version(45000000) == "VDxx"
+
+    def test_infer_vb_range(self):
+        assert _decode_siemens_version(25000000) == "VBxx"
+
+    def test_infer_va_or_older(self):
+        assert _decode_siemens_version(1000) == "VAxx"
+
+
+# ---------------------------------------------------------------------------
+# _decode_partial_fourier
+# ---------------------------------------------------------------------------
+
+class TestDecodePartialFourier:
+    @pytest.mark.parametrize("mode,expected", [
+        (1, 0.5), (2, 0.625), (4, 0.75), (8, 0.875), (16, 1.0), (32, 1.0),
+    ])
+    def test_int_modes(self, mode, expected):
+        assert _decode_partial_fourier(mode) == expected
+
+    def test_string_mode(self):
+        assert _decode_partial_fourier("0x4") == 0.75
+
+    def test_unknown_defaults_to_full(self):
+        assert _decode_partial_fourier(999) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# _nominal_field_strength (non-numeric branch)
+# ---------------------------------------------------------------------------
+
+class TestNominalFieldStrengthExtra:
+    def test_non_numeric_passthrough(self):
+        assert _nominal_field_strength("3T") == "3T"
+
+
+# ---------------------------------------------------------------------------
+# _extract_unique_b_values
+# ---------------------------------------------------------------------------
+
+class TestExtractUniqueBValues:
+    def test_empty_nested_is_b0(self):
+        assert _extract_unique_b_values([[]]) == [0.0]
+
+    def test_nested_values(self):
+        assert _extract_unique_b_values([[1000], [2000, 1000]]) == [1000.0, 2000.0]
+
+    def test_direct_values(self):
+        assert _extract_unique_b_values([0, 1000, 1000]) == [0.0, 1000.0]
+
+    def test_ignores_negative(self):
+        assert _extract_unique_b_values([-1, 500]) == [500.0]
+
+    def test_mixed(self):
+        assert _extract_unique_b_values([[], [1000], 2000]) == [0.0, 1000.0, 2000.0]
+
+
+# ---------------------------------------------------------------------------
+# _decode_sequence_type
+# ---------------------------------------------------------------------------
+
+class TestDecodeSequenceType:
+    def test_direct_mapping_gr(self):
+        assert _decode_sequence_type({"ucSequenceType": 1}) == "GR"
+
+    def test_direct_mapping_ep(self):
+        assert _decode_sequence_type({"ucSequenceType": 4}) == "EP"
+
+    def test_direct_mapping_se(self):
+        assert _decode_sequence_type({"ucSequenceType": 8}) == "SE"
+
+    def test_fallback_epi_name(self):
+        assert _decode_sequence_type({"tProtocolName": "ep2d_bold"}) == "EP"
+
+    def test_fallback_se_name(self):
+        assert _decode_sequence_type({"tSequenceFileName": "tse_t2"}) == "SE"
+
+    def test_fallback_default_gr(self):
+        assert _decode_sequence_type({"tProtocolName": "something_else"}) == "GR"
+
+    def test_inversion_mode_2_adds_ir(self):
+        result = _decode_sequence_type({"ucSequenceType": 1,
+                                        "sPrepPulses": {"ucInversion": 2}})
+        assert result == ["GR", "IR"]
+
+    def test_inversion_mode_ge_8_adds_ir(self):
+        result = _decode_sequence_type({"ucSequenceType": 8,
+                                        "sPrepPulses": {"ucInversion": 16}})
+        assert result == ["SE", "IR"]
+
+    def test_inversion_mode_4_not_ir(self):
+        result = _decode_sequence_type({"ucSequenceType": 1,
+                                        "sPrepPulses": {"ucInversion": 4}})
+        assert result == "GR"
+
+
+# ---------------------------------------------------------------------------
+# _physio_signal_method
+# ---------------------------------------------------------------------------
+
+class TestPhysioSignalMethod:
+    def test_returns_values(self):
+        data = {"sPhysioImaging": {"lSignal1": 2, "lMethod1": 4}}
+        assert _physio_signal_method(data) == (2, 4)
+
+    def test_absent_returns_none(self):
+        assert _physio_signal_method({}) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# _detect_scan_options - specific branches
+# ---------------------------------------------------------------------------
+
+class TestDetectScanOptions:
+    def test_per_reordering(self):
+        assert "PER" in _detect_scan_options({"sKSpace": {"unReordering": 2}})
+
+    def test_respiratory_gating(self):
+        data = {"sPhysioImaging": {"lSignal1": 16, "lMethod1": 4}}
+        assert "RG" in _detect_scan_options(data)
+
+    def test_peripheral_pulse_gating(self):
+        data = {"sPhysioImaging": {"lSignal1": 4, "lMethod1": 4}}
+        assert "PPG" in _detect_scan_options(data)
+
+    def test_partial_fourier_freq_and_phase(self):
+        data = {"sKSpace": {"ucReadoutPartialFourier": 4, "ucPhasePartialFourier": 8}}
+        opts = _detect_scan_options(data)
+        assert "PFF" in opts and "PFP" in opts
+
+    def test_water_sat_spatial_presat(self):
+        data = {"sPrepPulses": {"ucWaterSatMode": 2}}
+        assert "SP" in _detect_scan_options(data)
+
+    def test_empty_returns_empty_list(self):
+        assert _detect_scan_options({}) == []
+
+
+# ---------------------------------------------------------------------------
+# _detect_image_type - recon modes
+# ---------------------------------------------------------------------------
+
+class TestDetectImageType:
+    def test_magnitude_default(self):
+        it = _detect_image_type({"ucReconstructionMode": 1})
+        assert it[:3] == ["ORIGINAL", "PRIMARY", "M"]
+
+    def test_phase_only(self):
+        it = _detect_image_type({"ucReconstructionMode": 2})
+        assert "P" in it and "M" not in it[2:4]
+
+    def test_real_part(self):
+        it = _detect_image_type({"ucReconstructionMode": 4})
+        assert "R" in it
+
+    def test_mag_and_phase(self):
+        it = _detect_image_type({"ucReconstructionMode": 8})
+        assert "M" in it and "P" in it
+
+    def test_real_and_phase(self):
+        it = _detect_image_type({"ucReconstructionMode": 10})
+        assert "P" in it and "R" in it
+
+    def test_unknown_recon_defaults_m(self):
+        it = _detect_image_type({"ucReconstructionMode": 99})
+        assert "M" in it
+
+    def test_norm_flag(self):
+        it = _detect_image_type({"ucReconstructionMode": 1,
+                                 "sPreScanNormalizeFilter": {"ucMode": 2}})
+        assert "NORM" in it
+
+    def test_nd_flag(self):
+        it = _detect_image_type({"ucReconstructionMode": 1})
+        assert "ND" in it
+
+    def test_angio_flag(self):
+        it = _detect_image_type({"ucReconstructionMode": 1,
+                                 "sAngio": {"ucTOFInflow": 8}})
+        assert "ANGIO" in it
+
+    def test_distortion_correction_flag(self):
+        it = _detect_image_type({"ucReconstructionMode": 1,
+                                 "sDistortionCorrFilter": {"ucMode": 2}})
+        assert "DIS2D" in it
+
+
+# ---------------------------------------------------------------------------
+# _detect_sequence_variant - many branches
+# ---------------------------------------------------------------------------
+
+class TestDetectSequenceVariant:
+    def test_none_when_nothing(self):
+        assert _detect_sequence_variant({"tProtocolName": "plain",
+                                         "ucSequenceType": 99}) is None
+
+    def test_mp_from_inversion_mode(self):
+        v = _detect_sequence_variant({"tProtocolName": "irtse",
+                                      "sPrepPulses": {"ucInversion": 8}})
+        assert "MP" in v
+
+    def test_mp_from_meaningful_ti(self):
+        v = _detect_sequence_variant({"tProtocolName": "irscan",
+                                      "alTI": [1000000.0]})
+        assert "MP" in v
+
+    def test_non_mp_sequence_suppresses_mp(self):
+        v = _detect_sequence_variant({"tProtocolName": "bold_epi",
+                                      "alTI": [1000000.0]}) or []
+        assert "MP" not in v
+
+    def test_mtc(self):
+        v = _detect_sequence_variant({"tProtocolName": "x",
+                                      "sPrepPulses": {"lMTCMode": 2}})
+        assert "MTC" in v
+
+    def test_sk_from_segments(self):
+        v = _detect_sequence_variant({"tProtocolName": "x",
+                                      "sFastImaging": {"lSegments": 4}})
+        assert "SK" in v
+
+    def test_osp_from_phase_os(self):
+        v = _detect_sequence_variant({"tProtocolName": "x",
+                                      "sSpecPara": {"dPhaseOS": 1.5}})
+        assert "OSP" in v
+
+    def test_ss_from_sequence_type_2(self):
+        v = _detect_sequence_variant({"tProtocolName": "x", "ucSequenceType": 2})
+        assert "SS" in v
+
+    def test_sp_from_multi_echo_gre(self):
+        v = _detect_sequence_variant({"tProtocolName": "x", "ucSequenceType": 1,
+                                      "alTE": [2000, 5000]})
+        assert "SP" in v
+
+    def test_ep_from_epi_factor(self):
+        v = _detect_sequence_variant({"tProtocolName": "x",
+                                      "sFastImaging": {"lEPIFactor": 64}})
+        assert "EP" in v
+
+    def test_mp_from_name_additive(self):
+        v = _detect_sequence_variant({"tProtocolName": "t1_mprage"})
+        assert "MP" in v
+
+    def test_sp_from_name_additive(self):
+        v = _detect_sequence_variant({"tProtocolName": "flash_2d"})
+        assert "SP" in v
+
+    def test_sk_from_name_additive(self):
+        v = _detect_sequence_variant({"tProtocolName": "haste_cor"})
+        assert "SK" in v
+
+    def test_ep_from_name_additive(self):
+        v = _detect_sequence_variant({"tProtocolName": "ep2d_diff"})
+        assert "EP" in v
+
+    def test_mtc_from_name_additive(self):
+        v = _detect_sequence_variant({"tProtocolName": "mtc_prep"})
+        assert "MTC" in v
+
+    def test_ss_from_name_additive(self):
+        v = _detect_sequence_variant({"tProtocolName": "trufi_cine"})
+        assert "SS" in v
+
+    def test_ss_name_additive_without_type2(self):
+        # 'ssfp' in name but ucSequenceType != 2 -> SS added via additive branch
+        v = _detect_sequence_variant({"tProtocolName": "my_ssfp_scan",
+                                      "ucSequenceType": 1})
+        assert "SS" in v
+
+    def test_localizer_adds_sp_osp(self):
+        v = _detect_sequence_variant({"tProtocolName": "localizer"})
+        assert "SP" in v and "OSP" in v
+
+
+# ---------------------------------------------------------------------------
+# apply_pro_to_dicom_mapping - converters
+# ---------------------------------------------------------------------------
+
+class TestApplyProToDicomMapping:
+    def test_tr_list_multiple(self):
+        d = apply_pro_to_dicom_mapping({"alTR": [2000000, 3000000]})
+        assert d["RepetitionTime"] == [2000.0, 3000.0]
+
+    def test_tr_single_element_list(self):
+        d = apply_pro_to_dicom_mapping({"alTR": [2000000]})
+        assert d["RepetitionTime"] == 2000.0
+
+    def test_tr_scalar(self):
+        d = apply_pro_to_dicom_mapping({"alTR": 2000000})
+        assert d["RepetitionTime"] == 2000.0
+
+    def test_pat_mode_grappa(self):
+        d = apply_pro_to_dicom_mapping({"sPat": {"ucPATMode": 2}})
+        assert d["ParallelAcquisitionTechnique"] == "GRAPPA"
+
+    def test_pat_mode_sense(self):
+        d = apply_pro_to_dicom_mapping({"sPat": {"ucPATMode": 1}})
+        assert d["ParallelAcquisitionTechnique"] == "SENSE"
+
+    def test_phase_encoding_row(self):
+        d = apply_pro_to_dicom_mapping({"sSpecPara": {"lPhaseEncodingType": 1}})
+        assert d["InPlanePhaseEncodingDirection"] == "ROW"
+
+    def test_phase_encoding_col(self):
+        d = apply_pro_to_dicom_mapping({"sSpecPara": {"lPhaseEncodingType": 2}})
+        assert d["InPlanePhaseEncodingDirection"] == "COL"
+
+    def test_angio_flag(self):
+        d = apply_pro_to_dicom_mapping({"sAngio": {"ucPCFlowMode": 4}})
+        assert d["AngioFlag"] == "Y"
+
+    def test_bvalue_mapping(self):
+        d = apply_pro_to_dicom_mapping({"sDiffusion": {"alBValue": [[], [1000]]}})
+        assert d["DiffusionBValue"] == [0.0, 1000.0]
+
+    def test_software_version_mapping(self):
+        d = apply_pro_to_dicom_mapping({"ulVersion": 21710006})
+        assert d["SoftwareVersion"] == "VB17A"
+
+    def test_field_strength_mapping(self):
+        d = apply_pro_to_dicom_mapping(
+            {"sProtConsistencyInfo": {"flNominalB0": 2.89362}})
+        assert d["MagneticFieldStrength"] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# calculate_other_dicom_fields - many derived-field branches
+# ---------------------------------------------------------------------------
+
+class TestCalculateOtherDicomFields:
+    def test_echo_time_single_from_list(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"alTE": [5000], "lContrasts": 1})
+        assert d["EchoTime"] == 5.0
+
+    def test_echo_time_scalar(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"alTE": 5000})
+        assert d["EchoTime"] == 5.0
+
+    def test_echo_time_multi_limited_by_contrasts(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"alTE": [5000, 10000, 15000], "lContrasts": 2})
+        assert d["EchoTime"] == [5.0, 10.0]
+
+    def test_slice_normal(self):
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "sSliceArray": {"asSlice": [{"sNormal": {"dSag": 1.0, "dCor": 0.0, "dTra": 0.0}}]}})
+        assert d["SliceNormal"] == [1.0, 0.0, 0.0]
+
+    def test_slices_3d_partitions(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sKSpace": {"lPartitions": 64}})
+        assert d["Slices"] == 64
+
+    def test_slices_3d_images_per_slab(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sKSpace": {"lImagesPerSlab": 100}})
+        assert d["Slices"] == 100
+
+    def test_slices_2d_slice_array(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sSliceArray": {"lSize": 30}})
+        assert d["Slices"] == 30
+
+    def test_acquisition_matrix_row(self):
+        d = {"Rows": 128, "Columns": 96, "InPlanePhaseEncodingDirection": "ROW"}
+        calculate_other_dicom_fields(d, {})
+        assert d["AcquisitionMatrix"] == [0, 128, 96, 0]
+
+    def test_acquisition_matrix_col(self):
+        d = {"Rows": 128, "Columns": 96}
+        calculate_other_dicom_fields(d, {})
+        assert d["AcquisitionMatrix"] == [128, 0, 0, 96]
+
+    def test_pixel_spacing_and_percent_phase_fov(self):
+        d = {"Rows": 100, "Columns": 100}
+        calculate_other_dicom_fields(d, {
+            "sSliceArray": {"asSlice": [{"dReadoutFOV": 200.0, "dPhaseFOV": 150.0}]}})
+        assert d["PixelSpacing"] == [2.0, 1.5]
+        assert d["PercentPhaseFieldOfView"] == pytest.approx(75.0)
+
+    def test_pixel_bandwidth_with_oversampling(self):
+        d = {"Rows": 128, "Columns": 128}
+        calculate_other_dicom_fields(d, {
+            "sRXSPEC": {"alDwellTime": [10000]},
+            "sSpecPara": {"ucRemoveOversampling": 1}})
+        assert "PixelBandwidth" in d
+        assert "BandwidthPerPixelPhaseEncode" in d
+
+    def test_slice_thickness_3d(self):
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "sSliceArray": {"asSlice": [{"dThickness": 160.0}]},
+            "sKSpace": {"lImagesPerSlab": 80}})
+        assert d["SliceThickness"] == 2.0
+        assert d["SlabThickness"] == 160.0
+        assert d["MRAcquisitionType"] == "3D"
+
+    def test_slice_thickness_2d(self):
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "sSliceArray": {"asSlice": [{"dThickness": 3.0}]}})
+        assert d["SliceThickness"] == 3.0
+        assert d["MRAcquisitionType"] == "2D"
+
+    def test_spacing_between_slices(self):
+        d = {"SliceThickness": 4.0}
+        calculate_other_dicom_fields(d, {
+            "sGroupArray": {"asGroup": [{"dDistFact": 0.2}]}})
+        assert d["SpacingBetweenSlices"] == pytest.approx(4.8)
+
+    def test_patient_position_mapping(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sPatientPosition": {"ucPatientPosition": 1}})
+        assert d["PatientPosition"] == "HFS"
+
+    def test_patient_position_unknown(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sPatientPosition": {"ucPatientPosition": 99}})
+        assert d["PatientPosition"] == "Unknown"
+
+    def test_acquisition_time(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sMeasStartTime": {"lTime": 3661500}})
+        # 1h 1m 1s 500ms
+        assert d["AcquisitionTime"] == "010101.500000"
+
+    def test_partial_fourier_yes_phase(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sKSpace": {"ucPhasePartialFourier": 8}})
+        assert d["PartialFourier"] == "YES"
+        assert d["PartialFourierDirection"] == "PHASE"
+
+    def test_partial_fourier_frequency(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sKSpace": {"ucReadoutPartialFourier": 8}})
+        assert d["PartialFourierDirection"] == "FREQUENCY"
+
+    def test_partial_fourier_slice(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sKSpace": {"ucSlicePartialFourier": 8}})
+        assert d["PartialFourierDirection"] == "SLICE_SELECT"
+
+    def test_partial_fourier_combination(self):
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "sKSpace": {"ucPhasePartialFourier": 8, "ucReadoutPartialFourier": 4}})
+        assert d["PartialFourierDirection"] == "COMBINATION"
+
+    def test_partial_fourier_no(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sKSpace": {"ucPhasePartialFourier": 16}})
+        assert d["PartialFourier"] == "NO"
+        assert "PartialFourierDirection" not in d
+
+    def test_temporal_resolution(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"lRepetitions": 10, "alTR": [2000000]})
+        assert d["NumberOfTemporalPositions"] == 11
+        assert d["TemporalResolution"] == 2000.0
+
+    def test_gradient_echo_train_length_tse(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sFastImaging": {"lTurboFactor": 8}})
+        assert d["GradientEchoTrainLength"] == 0
+
+    def test_gradient_echo_train_length_epi(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sFastImaging": {"lEPIFactor": 64}})
+        assert d["GradientEchoTrainLength"] == 64
+
+    def test_gradient_echo_train_length_multi_echo_gre(self):
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "ucSequenceType": 1, "alTE": [2000, 5000, 8000], "lContrasts": 3})
+        assert d["GradientEchoTrainLength"] == 3
+
+    def test_gradient_echo_train_length_single_gre(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"ucSequenceType": 1, "alTE": [2000]})
+        assert d["GradientEchoTrainLength"] == 1
+
+    def test_echo_train_length_tse_segmented(self):
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "sFastImaging": {"lTurboFactor": 4, "lSegments": 2}})
+        assert d["EchoTrainLength"] == 8
+
+    def test_echo_train_length_epi(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"sFastImaging": {"lEPIFactor": 32}})
+        assert d["EchoTrainLength"] == 32
+
+    def test_echo_train_length_contrasts(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"lContrasts": 4, "alTE": [1, 2, 3, 4, 5]})
+        assert d["EchoTrainLength"] == 4
+
+    def test_echo_train_length_from_alte_length(self):
+        d = {}
+        calculate_other_dicom_fields(d, {"alTE": [1000, 2000]})
+        assert d["EchoTrainLength"] == 2
+
+    def test_multiple_inversion_times_ir(self):
+        # MP2RAGE-style: ucInversion=16 -> IR, two TIs -> list of TIs in ms
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "ucSequenceType": 1,
+            "sPrepPulses": {"ucInversion": 16},
+            "alTI": [900000, 2750000]})
+        assert d["InversionTime"] == [900.0, 2750.0]
+
+    def test_scalar_inversion_time_ir(self):
+        # scalar alTI (non-list) with IR sequence -> single ms value
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "ucSequenceType": 1,
+            "sPrepPulses": {"ucInversion": 8},
+            "alTI": 1000000})
+        assert d["InversionTime"] == 1000.0
+
+    def test_trigger_source_and_time(self):
+        d = {}
+        calculate_other_dicom_fields(d, {
+            "sPhysioImaging": {"lSignal1": 2, "lMethod1": 4,
+                               "sPhysioECG": {"lTriggerWindow": 50}}})
+        assert d["TriggerSourceOrType"] == "ECG"
+        assert d["TriggerTime"] == 50
+
+
+# ---------------------------------------------------------------------------
+# Schema-format helpers
+# ---------------------------------------------------------------------------
+
+class TestDetermineImageTypesForSeries:
+    def test_mag_phase_recon8(self):
+        types = _determine_image_types_for_series(8, {"ImageType": ["ORIGINAL", "PRIMARY", "M"]})
+        assert len(types) == 2
+        assert any("P" in t for t in types)
+
+    def test_phase_only_recon2(self):
+        types = _determine_image_types_for_series(2, {"ImageType": ["ORIGINAL", "PRIMARY", "M"]})
+        assert len(types) == 1
+        assert "P" in types[0]
+
+    def test_magnitude_default(self):
+        types = _determine_image_types_for_series(1, {})
+        assert len(types) == 1
+        assert "M" in types[0]
+
+    def test_mag_phase_appends_missing(self):
+        # base without M or P forces the append branches
+        types = _determine_image_types_for_series(8, {"ImageType": ["ORIGINAL", "PRIMARY"]})
+        assert "M" in types[0] and "P" in types[1]
+
+    def test_phase_only_appends_missing(self):
+        types = _determine_image_types_for_series(2, {"ImageType": ["ORIGINAL", "PRIMARY"]})
+        assert "P" in types[0]
+
+    def test_magnitude_appends_missing(self):
+        types = _determine_image_types_for_series(1, {"ImageType": ["ORIGINAL", "PRIMARY"]})
+        assert "M" in types[0]
+
+
+class TestExtractSeriesParameters:
+    def test_multi_echo_creates_series(self):
+        params = _extract_series_parameters({"EchoTime": [2.5, 5.0]}, {})
+        assert params["EchoTime"] == [2.5, 5.0]
+
+    def test_single_echo_no_series(self):
+        params = _extract_series_parameters({"EchoTime": 2.5}, {})
+        assert params == {}
+
+    def test_mag_phase_recon_creates_image_type_series(self):
+        params = _extract_series_parameters(
+            {"EchoTime": 2.5, "ImageType": ["ORIGINAL", "PRIMARY", "M"]},
+            {"ucReconstructionMode": 8})
+        assert "ImageType" in params
+        # single echo added back once series-creating params exist
+        assert params["EchoTime"] == [2.5]
+
+    def test_multi_inversion_times(self):
+        params = _extract_series_parameters({"InversionTime": [0.9, 2.75]}, {})
+        assert params["InversionTime"] == [0.9, 2.75]
+
+    def test_scalar_inversion_with_multi_echo(self):
+        # scalar InversionTime hits the elif branch; stays at acquisition level
+        params = _extract_series_parameters(
+            {"EchoTime": [2.5, 5.0], "InversionTime": 0.9}, {})
+        assert "EchoTime" in params
+        assert "InversionTime" not in params
+
+    def test_single_echo_list_added_back(self):
+        params = _extract_series_parameters(
+            {"EchoTime": [2.5], "InversionTime": [0.9, 2.75]}, {})
+        assert params["EchoTime"] == [2.5]
+
+
+class TestGenerateSeriesCombinations:
+    def test_empty_returns_empty(self):
+        assert _generate_series_combinations({}) == []
+
+    def test_single_param(self):
+        series = _generate_series_combinations({"EchoTime": [2.5, 5.0]})
+        assert len(series) == 2
+        assert series[0]["name"] == "Series 01"
+        assert series[0]["fields"][0] == {"field": "EchoTime", "value": 2.5}
+
+    def test_cartesian_product(self):
+        series = _generate_series_combinations({
+            "EchoTime": [2.5, 5.0],
+            "ImageType": [["ORIGINAL", "PRIMARY", "M"], ["ORIGINAL", "PRIMARY", "P"]]})
+        assert len(series) == 4
+
+    def test_other_param_ordering(self):
+        series = _generate_series_combinations({"CustomParam": [1, 2]})
+        assert len(series) == 2
+        assert series[0]["fields"][0]["field"] == "CustomParam"
+
+
+class TestClassifyFields:
+    def test_skips_metadata_and_empty_and_none(self):
+        dicom = {"ProtocolName": "x", "PRO_Path": "/a", "PRO_FileName": "a.pro",
+                 "SeriesDescription": "", "Missing": None, "EchoTime": 2.5}
+        acq, series_varying = _classify_fields(dicom, {"EchoTime": [2.5, 5.0]})
+        field_names = {f["field"] for f in acq}
+        assert "ProtocolName" in field_names
+        assert "PRO_Path" not in field_names
+        assert "SeriesDescription" not in field_names
+        assert "Missing" not in field_names
+        assert "EchoTime" not in field_names  # series-varying
+        assert "EchoTime" in series_varying
+
+
+class TestConvertFlatToSchemaFormat:
+    def test_structure(self):
+        dicom = {"ProtocolName": "test", "EchoTime": [2.5, 5.0]}
+        result = _convert_flat_to_schema_format(dicom, {}, "/tmp/x.pro")
+        assert result["acquisition_info"]["protocol_name"] == "test"
+        assert result["acquisition_info"]["source_type"] == "pro_file"
+        assert result["acquisition_info"]["pro_filename"] == "x.pro"
+        assert len(result["series"]) == 2
+        assert isinstance(result["fields"], list)
+
+
+# ---------------------------------------------------------------------------
+# .pro loader error paths and schema format on real fixtures
+# ---------------------------------------------------------------------------
+
+class TestProLoaderErrorPaths:
+    def test_load_pro_file_parse_error(self, tmp_path, monkeypatch):
+        bad = tmp_path / "bad.pro"
+        bad.write_text("### ASCCONV BEGIN ###\nalTE[0] = 5\n### ASCCONV END ###\n")
+
+        def boom(*a, **k):
+            raise ValueError("parse blew up")
+
+        monkeypatch.setattr(pro_mod, "parse_buffer", boom)
+        with pytest.raises(Exception, match="Failed to parse .pro file"):
+            load_pro_file(str(bad))
+
+    def test_load_pro_file_schema_format_parse_error(self, tmp_path, monkeypatch):
+        bad = tmp_path / "bad2.pro"
+        bad.write_text("### ASCCONV BEGIN ###\nalTE[0] = 5\n### ASCCONV END ###\n")
+
+        def boom(*a, **k):
+            raise ValueError("parse blew up")
+
+        monkeypatch.setattr(pro_mod, "parse_buffer", boom)
+        with pytest.raises(Exception, match="Failed to parse .pro file"):
+            load_pro_file_schema_format(str(bad))
+
+    def test_load_pro_file_schema_format_nonexistent(self):
+        with pytest.raises(FileNotFoundError):
+            load_pro_file_schema_format(str(FIXTURES_DIR / "nope.pro"))
+
+    def test_load_pro_file_schema_format_real_fixture(self):
+        pro_file = FIXTURES_DIR / "PRODUCT__ep2d_bold__p2_sms1.pro"
+        result = load_pro_file_schema_format(str(pro_file))
+        assert "acquisition_info" in result
+        assert "series" in result
+        assert result["acquisition_info"]["source_type"] == "pro_file"
+
+
+class TestProSessionSimple:
+    def test_no_source_raises(self):
+        with pytest.raises(ValueError, match="Either session_dir or pro_files"):
+            load_pro_session_simple()
+
+    def test_pro_files_list(self):
+        files = [str(p) for p in FIXTURES_DIR.glob("*.pro")]
+        df = load_pro_session_simple(pro_files=files)
+        assert isinstance(df, pd.DataFrame)
+        assert "Acquisition" in df.columns
+
+    def test_progress_callback(self):
+        files = [str(p) for p in FIXTURES_DIR.glob("*.pro")]
+        seen = []
+        load_pro_session_simple(pro_files=files, progress_function=seen.append)
+        assert seen and seen[-1] == 100
+
+    def test_failed_file_warns_and_continues(self, tmp_path, monkeypatch, capsys):
+        good = str(next(FIXTURES_DIR.glob("*.pro")))
+        real = pro_mod.load_pro_file
+
+        def maybe_fail(path):
+            if path == "FAKE.pro":
+                raise RuntimeError("nope")
+            return real(path)
+
+        monkeypatch.setattr(pro_mod, "load_pro_file", maybe_fail)
+        df = load_pro_session_simple(pro_files=["FAKE.pro", good])
+        assert len(df) == 1
+        assert "Failed to load" in capsys.readouterr().out
+
+    def test_all_fail_raises(self, tmp_path, monkeypatch):
+        def boom(path):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(pro_mod, "load_pro_file", boom)
+        with pytest.raises(ValueError, match="No valid .pro files"):
+            load_pro_session_simple(pro_files=["a.pro"])
+
+
+# ---------------------------------------------------------------------------
+# EXAR: pure helpers
+# ---------------------------------------------------------------------------
+
+class TestExarHelpers:
+    def test_decompress_raw_deflate_roundtrip(self):
+        raw = b"hello protocol world"
+        comp = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        data = comp.compress(raw) + comp.flush()
+        assert _decompress_raw_deflate(data) == raw
+
+    def test_decompress_raw_deflate_invalid(self):
+        assert _decompress_raw_deflate(b"not compressed") is None
+
+    def test_extract_protocol_text_json_wrapper(self):
+        wrapped = ('EDF V1: ContentType=...EdfProtocolContent;'
+                   '{"Data": "tProtocolName = \\"abc\\""}')
+        assert _extract_protocol_text_from_xprotocol(wrapped) == 'tProtocolName = "abc"'
+
+    def test_extract_protocol_text_no_json(self):
+        assert _extract_protocol_text_from_xprotocol("no braces here") is None
+
+    def test_extract_protocol_text_fallback(self):
+        text = 'garbage {not json} but has tProtocolName inside'
+        assert _extract_protocol_text_from_xprotocol(text) == text
+
+    def test_extract_protocol_text_empty_data(self):
+        assert _extract_protocol_text_from_xprotocol('{"Data": ""}') is None
+
+
+# ---------------------------------------------------------------------------
+# EXAR: synthesize a tiny SQLite .exar1 archive to exercise DB-read paths
+# ---------------------------------------------------------------------------
+
+def _build_exar(path, protocol_texts, include_string=True, include_branch=True,
+                only_non_protocol=False):
+    """Build a minimal .exar1-like SQLite DB."""
+    conn = sqlite3.connect(str(path))
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE Content (Hash TEXT PRIMARY KEY, Data BLOB)")
+    cur.execute("CREATE TABLE Instance (Id INTEGER PRIMARY KEY, "
+                "InstanceType TEXT, ContentHash TEXT)")
+    cur.execute("CREATE TABLE Branch (Baseline TEXT)")
+
+    def raw_deflate(b):
+        c = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        return c.compress(b) + c.flush()
+
+    inst_id = 0
+    if not only_non_protocol:
+        for text in protocol_texts:
+            wrapper = 'EDF V1;' + json.dumps({"Data": text})
+            blob = raw_deflate(wrapper.encode("utf-8"))
+            h = hashlib.sha1(blob).hexdigest()
+            cur.execute("INSERT INTO Content VALUES (?, ?)", (h, blob))
+            inst_id += 1
+            cur.execute("INSERT INTO Instance VALUES (?, ?, ?)",
+                        (inst_id, "EdfProtocol", h))
+
+    if include_string:
+        name_blob = raw_deflate(json.dumps({"Texts": {"en": "MyFolder"}}).encode("utf-8"))
+        h = hashlib.sha1(name_blob).hexdigest()
+        cur.execute("INSERT INTO Content VALUES (?, ?)", (h, name_blob))
+        inst_id += 1
+        cur.execute("INSERT INTO Instance VALUES (?, ?, ?)", (inst_id, "EdfString", h))
+
+    if include_branch:
+        cur.execute("INSERT INTO Branch VALUES (?)",
+                    ("MAJORVERSION:VA60A, PROTOCOL:66010002",))
+
+    conn.commit()
+    conn.close()
+
+
+PROTO_TEXT_SIMPLE = (
+    "### ASCCONV BEGIN ###\n"
+    'tProtocolName = "exar_test"\n'
+    "ucSequenceType = 1\n"
+    "alTE[0] = 5000\n"
+    "alTR[0] = 2000000\n"
+    "lContrasts = 1\n"
+    "### ASCCONV END ###\n"
+)
+
+PROTO_TEXT_MULTIECHO = (
+    "### ASCCONV BEGIN ###\n"
+    'tProtocolName = "exar_multiecho"\n'
+    "ucSequenceType = 1\n"
+    "alTE[0] = 5000\n"
+    "alTE[1] = 10000\n"
+    "lContrasts = 2\n"
+    "### ASCCONV END ###\n"
+)
+
+
+class TestExarDescribeContents:
+    def test_describe_with_protocols(self, tmp_path):
+        p = tmp_path / "a.exar1"
+        _build_exar(p, [PROTO_TEXT_SIMPLE])
+        summary, has_protocols = _describe_exar_contents(str(p))
+        assert has_protocols is True
+        assert "software version VA60A" in summary
+        assert "MyFolder" in summary
+        assert "EdfProtocol" in summary
+
+    def test_describe_no_protocols(self, tmp_path):
+        p = tmp_path / "b.exar1"
+        _build_exar(p, [], only_non_protocol=True)
+        summary, has_protocols = _describe_exar_contents(str(p))
+        assert has_protocols is False
+
+    def test_describe_malformed_string_entries(self, tmp_path):
+        # EdfString entries that fail to decompress / have no JSON / bad JSON,
+        # and no Branch row (version stays None) -> exercises the continue branches.
+        p = tmp_path / "malformed.exar1"
+        conn = sqlite3.connect(str(p))
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE Content (Hash TEXT PRIMARY KEY, Data BLOB)")
+        cur.execute("CREATE TABLE Instance (Id INTEGER PRIMARY KEY, "
+                    "InstanceType TEXT, ContentHash TEXT)")
+        cur.execute("CREATE TABLE Branch (Baseline TEXT)")
+
+        def deflate(b):
+            c = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+            return c.compress(b) + c.flush()
+
+        entries = [
+            b"\x00not deflate",                 # fails decompress -> continue
+            deflate(b"no braces at all"),        # no '{' -> continue
+            deflate(b"prefix {not valid json}"), # bad JSON -> continue
+        ]
+        for i, blob in enumerate(entries, 1):
+            h = f"h{i}"
+            cur.execute("INSERT INTO Content VALUES (?, ?)", (h, blob))
+            cur.execute("INSERT INTO Instance VALUES (?, ?, ?)", (i, "EdfString", h))
+        # one EdfProtocol so has_protocols is True
+        cur.execute("INSERT INTO Content VALUES (?, ?)", ("hp", deflate(b"proto")))
+        cur.execute("INSERT INTO Instance VALUES (?, ?, ?)", (99, "EdfProtocol", "hp"))
+        conn.commit()
+        conn.close()
+
+        summary, has_protocols = _describe_exar_contents(str(p))
+        assert has_protocols is True
+        assert "software version" not in summary  # no Branch/version
+        assert "folder tree" not in summary        # no valid names
+
+    def test_describe_empty_instance_table(self, tmp_path):
+        # Valid DB but no Instance rows -> "contains no entries at all"
+        p = tmp_path / "emptytables.exar1"
+        conn = sqlite3.connect(str(p))
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE Content (Hash TEXT PRIMARY KEY, Data BLOB)")
+        cur.execute("CREATE TABLE Instance (Id INTEGER PRIMARY KEY, "
+                    "InstanceType TEXT, ContentHash TEXT)")
+        cur.execute("CREATE TABLE Branch (Baseline TEXT)")
+        conn.commit()
+        conn.close()
+        summary, has_protocols = _describe_exar_contents(str(p))
+        assert has_protocols is False
+        assert "contains no entries at all" in summary
+
+    def test_describe_bad_db_returns_empty(self, tmp_path):
+        p = tmp_path / "notdb.exar1"
+        p.write_bytes(b"this is not sqlite")
+        summary, has_protocols = _describe_exar_contents(str(p))
+        assert summary == "" and has_protocols is False
+
+
+class TestExtractProtocolsFromExar:
+    def test_extract(self, tmp_path):
+        p = tmp_path / "c.exar1"
+        _build_exar(p, [PROTO_TEXT_SIMPLE, PROTO_TEXT_MULTIECHO])
+        texts = _extract_protocols_from_exar(str(p))
+        assert len(texts) == 2
+        assert any("exar_test" in t for t in texts)
+
+    def test_skips_null_and_bad_content(self, tmp_path):
+        p = tmp_path / "skip.exar1"
+        conn = sqlite3.connect(str(p))
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE Content (Hash TEXT PRIMARY KEY, Data BLOB)")
+        cur.execute("CREATE TABLE Instance (Id INTEGER PRIMARY KEY, "
+                    "InstanceType TEXT, ContentHash TEXT)")
+
+        def deflate(b):
+            c = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+            return c.compress(b) + c.flush()
+
+        # NULL content (LEFT JOIN miss) -> `if not data: continue`
+        cur.execute("INSERT INTO Instance VALUES (?, ?, ?)", (1, "EdfProtocol", "missing"))
+        # undecompressible content -> `if not decompressed: continue`
+        cur.execute("INSERT INTO Content VALUES (?, ?)", ("bad", b"\x00not deflate"))
+        cur.execute("INSERT INTO Instance VALUES (?, ?, ?)", (2, "EdfProtocol", "bad"))
+        # a good one
+        wrapper = 'EDF;' + json.dumps({"Data": PROTO_TEXT_SIMPLE})
+        cur.execute("INSERT INTO Content VALUES (?, ?)", ("good", deflate(wrapper.encode())))
+        cur.execute("INSERT INTO Instance VALUES (?, ?, ?)", (3, "EdfProtocol", "good"))
+        conn.commit()
+        conn.close()
+
+        texts = _extract_protocols_from_exar(str(p))
+        assert len(texts) == 1
+
+    def test_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            _extract_protocols_from_exar(str(tmp_path / "no.exar1"))
+
+    def test_bad_sqlite_raises(self, tmp_path):
+        p = tmp_path / "bad.exar1"
+        p.write_bytes(b"not a sqlite database at all")
+        with pytest.raises(Exception, match="Failed to read EXAR"):
+            _extract_protocols_from_exar(str(p))
+
+
+class TestLoadExarFile:
+    def test_load_ok(self, tmp_path):
+        p = tmp_path / "d.exar1"
+        _build_exar(p, [PROTO_TEXT_SIMPLE, PROTO_TEXT_MULTIECHO])
+        results = load_exar_file(str(p))
+        assert len(results) == 2
+        assert all("EXAR_Path" in r for r in results)
+        assert all(r["Manufacturer"] == "Siemens" for r in results)
+
+    def test_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_exar_file(str(tmp_path / "no.exar1"))
+
+    def test_no_protocols_message(self, tmp_path):
+        p = tmp_path / "empty.exar1"
+        _build_exar(p, [], only_non_protocol=True)
+        with pytest.raises(Exception, match="no protocol"):
+            load_exar_file(str(p))
+
+    def test_protocol_entries_but_undecodable(self, tmp_path):
+        # EdfProtocol content decompresses but yields no protocol text -> the
+        # "contains protocol entries, but none could be decoded" branch.
+        p = tmp_path / "undecodable.exar1"
+        conn = sqlite3.connect(str(p))
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE Content (Hash TEXT PRIMARY KEY, Data BLOB)")
+        cur.execute("CREATE TABLE Instance (Id INTEGER PRIMARY KEY, "
+                    "InstanceType TEXT, ContentHash TEXT)")
+        cur.execute("CREATE TABLE Branch (Baseline TEXT)")
+        c = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        blob = c.compress(b"no json and no protocol marker") + c.flush()
+        cur.execute("INSERT INTO Content VALUES (?, ?)", ("h", blob))
+        cur.execute("INSERT INTO Instance VALUES (?, ?, ?)", (1, "EdfProtocol", "h"))
+        conn.commit()
+        conn.close()
+        with pytest.raises(Exception, match="none of them could be decoded"):
+            load_exar_file(str(p))
+
+    def test_schema_format_undecodable_returns_empty(self, tmp_path):
+        # No protocol texts but load_exar_file raises inside -> schema variant
+        # re-raises via the diagnostics call.
+        p = tmp_path / "undecodable2.exar1"
+        conn = sqlite3.connect(str(p))
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE Content (Hash TEXT PRIMARY KEY, Data BLOB)")
+        cur.execute("CREATE TABLE Instance (Id INTEGER PRIMARY KEY, "
+                    "InstanceType TEXT, ContentHash TEXT)")
+        cur.execute("CREATE TABLE Branch (Baseline TEXT)")
+        c = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        blob = c.compress(b"nothing useful") + c.flush()
+        cur.execute("INSERT INTO Content VALUES (?, ?)", ("h", blob))
+        cur.execute("INSERT INTO Instance VALUES (?, ?, ?)", (1, "EdfProtocol", "h"))
+        conn.commit()
+        conn.close()
+        with pytest.raises(Exception):
+            load_exar_file_schema_format(str(p))
+
+    def test_load_schema_format(self, tmp_path):
+        p = tmp_path / "e.exar1"
+        _build_exar(p, [PROTO_TEXT_MULTIECHO])
+        results = load_exar_file_schema_format(str(p))
+        assert len(results) == 1
+        info = results[0]["acquisition_info"]
+        assert info["source_type"] == "exar1"
+        assert info["exar_filename"] == "e.exar1"
+        # multi-echo should expand into >1 series
+        assert len(results[0]["series"]) >= 2
+
+    def test_schema_format_nonexistent(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_exar_file_schema_format(str(tmp_path / "no.exar1"))
+
+    def test_schema_format_no_protocols_raises(self, tmp_path):
+        p = tmp_path / "empty2.exar1"
+        _build_exar(p, [], only_non_protocol=True)
+        with pytest.raises(Exception):
+            load_exar_file_schema_format(str(p))
+
+    def test_load_exar_file_protocol_parse_warning(self, tmp_path, monkeypatch, capsys):
+        # Force apply_pro_to_dicom_mapping to raise so the per-protocol warning
+        # path (with tProtocolName regex extraction) is exercised.
+        p = tmp_path / "warn.exar1"
+        _build_exar(p, [PROTO_TEXT_SIMPLE])
+
+        def boom(*a, **k):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(pro_mod, "apply_pro_to_dicom_mapping", boom)
+        results = load_exar_file(str(p))
+        assert results == []
+        out = capsys.readouterr().out
+        assert "exar_test" in out and "kaboom" in out
+
+    def test_load_exar_schema_protocol_parse_warning(self, tmp_path, monkeypatch, capsys):
+        p = tmp_path / "warn2.exar1"
+        _build_exar(p, [PROTO_TEXT_SIMPLE])
+
+        def boom(*a, **k):
+            raise RuntimeError("kaboom2")
+
+        monkeypatch.setattr(pro_mod, "apply_pro_to_dicom_mapping", boom)
+        results = load_exar_file_schema_format(str(p))
+        assert results == []
+        out = capsys.readouterr().out
+        assert "exar_test" in out and "kaboom2" in out
+
+
+class TestLoadExarSession:
+    def test_no_source_raises(self):
+        with pytest.raises(ValueError, match="Either session_dir or exar_files"):
+            load_exar_session()
+
+    def test_no_files_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="No .exar1 files"):
+            load_exar_session(session_dir=str(tmp_path))
+
+    def test_load_session_from_list(self, tmp_path):
+        p = tmp_path / "f.exar1"
+        _build_exar(p, [PROTO_TEXT_SIMPLE, PROTO_TEXT_MULTIECHO])
+        df = load_exar_session(exar_files=[str(p)])
+        assert isinstance(df, pd.DataFrame)
+        assert "Acquisition" in df.columns
+        assert len(df) == 2
+
+    def test_load_session_from_dir_with_progress(self, tmp_path):
+        p = tmp_path / "g.exar1"
+        _build_exar(p, [PROTO_TEXT_SIMPLE])
+        seen = []
+        df = load_exar_session(session_dir=str(tmp_path),
+                               progress_function=seen.append)
+        assert isinstance(df, pd.DataFrame)
+        assert seen and seen[-1] == 100
+
+    def test_all_fail_raises(self, tmp_path):
+        p = tmp_path / "bad.exar1"
+        p.write_bytes(b"not sqlite")
+        with pytest.raises(ValueError, match="No valid protocols"):
+            load_exar_session(exar_files=[str(p)])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/dicompare/tests/test_session_coverage.py
+++ b/dicompare/tests/test_session_coverage.py
@@ -1,0 +1,760 @@
+"""
+Coverage-focused unit tests for:
+  - dicompare/session/mapping.py
+  - dicompare/session/acquisition.py
+  - dicompare/data_utils.py
+
+These tests exercise branches that were previously uncovered: the min/max range
+scoring path, missing-column handling in map_to_json_reference, the interactive
+(curses-driven) mapping function via a scripted fake stdscr, orphan-series run
+assignment and settings-split logic in acquisition assignment, and the nested
+flatten / AcquisitionDateTime handling in data_utils.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from dicompare.session import mapping as mapping_mod
+from dicompare.session.mapping import (
+    calculate_field_score,
+    map_to_json_reference,
+    interactive_mapping_to_json_reference,
+)
+from dicompare.session.acquisition import (
+    assign_acquisition_and_run_numbers,
+    _dicom_time_to_seconds,
+    _normalize_series_description_for_run_detection,
+)
+from dicompare import data_utils
+from dicompare.data_utils import (
+    make_dataframe_hashable,
+    _flatten_nested_dict,
+    _reduce_flattened_keys,
+    _convert_to_plain_python_types,
+    _process_dicom_metadata,
+    prepare_session_dataframe,
+)
+from dicompare.config import MAX_DIFF_SCORE
+
+
+# ---------------------------------------------------------------------------
+# mapping.calculate_field_score - min/max range constraints (lines 82-96)
+# ---------------------------------------------------------------------------
+class TestCalculateFieldScoreRange:
+    def test_within_min_max_range(self):
+        assert calculate_field_score(None, 5, min_value=0, max_value=10) == 0
+
+    def test_only_min_in_range(self):
+        assert calculate_field_score(None, 5, min_value=0) == 0
+
+    def test_only_max_in_range(self):
+        assert calculate_field_score(None, 5, max_value=10) == 0
+
+    def test_below_min_value(self):
+        # actual below min: distance from boundary = min - actual = 3
+        assert calculate_field_score(None, 2, min_value=5) == 3
+
+    def test_below_min_value_capped(self):
+        # distance would be huge -> capped at MAX_DIFF_SCORE
+        assert calculate_field_score(None, -100, min_value=5) == MAX_DIFF_SCORE
+
+    def test_above_max_value(self):
+        # actual above max: distance = actual - max = 4
+        assert calculate_field_score(None, 14, max_value=10) == 4
+
+    def test_above_max_value_capped(self):
+        assert calculate_field_score(None, 1000, max_value=10) == MAX_DIFF_SCORE
+
+    def test_non_numeric_with_range_constraint(self):
+        # non-numeric actual under a range constraint -> fixed penalty of 5
+        assert calculate_field_score(None, "notanumber", min_value=0, max_value=10) == 5
+
+
+# ---------------------------------------------------------------------------
+# mapping.map_to_json_reference
+# ---------------------------------------------------------------------------
+def _simple_ref_session():
+    return {
+        "acquisitions": {
+            "acqA": {
+                "fields": [{"field": "ProtocolName", "value": "protoA"}],
+                "series": [],
+            },
+            "acqB": {
+                "fields": [{"field": "ProtocolName", "value": "protoB"}],
+                "series": [],
+            },
+        }
+    }
+
+
+def _simple_in_df():
+    return pd.DataFrame(
+        [
+            {"Acquisition": "in_a", "ProtocolName": "protoA"},
+            {"Acquisition": "in_b", "ProtocolName": "protoB"},
+        ]
+    )
+
+
+class TestMapToJsonReference:
+    def test_basic_assignment(self):
+        ref = _simple_ref_session()
+        df = _simple_in_df()
+        result = map_to_json_reference(df, ref)
+        assert result == {"acqA": "in_a", "acqB": "in_b"}
+
+    def test_return_costs(self):
+        ref = _simple_ref_session()
+        df = _simple_in_df()
+        mapping, costs = map_to_json_reference(df, ref, return_costs=True)
+        assert mapping == {"acqA": "in_a", "acqB": "in_b"}
+        assert "assigned_costs" in costs
+        assert "ref_acq_list" in costs
+        assert "input_acq_list" in costs
+        # Perfect matches -> zero cost
+        assert costs["assigned_costs"]["acqA"] == 0.0
+        assert costs["assigned_costs"]["acqB"] == 0.0
+
+    def test_missing_column_yields_high_cost(self):
+        # Reference references a field absent from the input df (line 265 path):
+        # actual_value = None -> MAX_DIFF_SCORE penalty.
+        ref = {
+            "acquisitions": {
+                "acqX": {
+                    "fields": [{"field": "NotPresentField", "value": "whatever"}],
+                    "series": [],
+                }
+            }
+        }
+        df = pd.DataFrame([{"Acquisition": "in_only", "ProtocolName": "p"}])
+        mapping, costs = map_to_json_reference(df, ref, return_costs=True)
+        assert mapping == {"acqX": "in_only"}
+        assert costs["assigned_costs"]["acqX"] == MAX_DIFF_SCORE
+
+    def test_multiple_values_in_column_high_cost(self):
+        # Column present but with multiple distinct values -> actual_value None branch.
+        ref = {
+            "acquisitions": {
+                "acqM": {
+                    "fields": [{"field": "ProtocolName", "value": "protoA"}],
+                    "series": [],
+                }
+            }
+        }
+        df = pd.DataFrame(
+            [
+                {"Acquisition": "in_multi", "ProtocolName": "protoA"},
+                {"Acquisition": "in_multi", "ProtocolName": "protoB"},
+            ]
+        )
+        mapping, costs = map_to_json_reference(df, ref, return_costs=True)
+        assert mapping == {"acqM": "in_multi"}
+        assert costs["assigned_costs"]["acqM"] == MAX_DIFF_SCORE
+
+    def test_with_series_definitions(self):
+        # Exercise the nested series-assignment branch (compute_series_cost_matrix).
+        ref = {
+            "acquisitions": {
+                "acqS": {
+                    "fields": [{"field": "ProtocolName", "value": "protoS"}],
+                    "series": [
+                        {"name": "s1", "fields": [{"field": "ImageType", "value": "M"}]},
+                        {"name": "s2", "fields": [{"field": "ImageType", "value": "P"}]},
+                    ],
+                }
+            }
+        }
+        df = pd.DataFrame(
+            [
+                {"Acquisition": "in_s", "ProtocolName": "protoS", "ImageType": "M"},
+                {"Acquisition": "in_s", "ProtocolName": "protoS", "ImageType": "P"},
+            ]
+        )
+        mapping, costs = map_to_json_reference(df, ref, return_costs=True)
+        assert mapping == {"acqS": "in_s"}
+        # ProtocolName matches and both series match perfectly -> zero cost
+        assert costs["assigned_costs"]["acqS"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# mapping.interactive_mapping_to_json_reference (curses, lines 329-438)
+# ---------------------------------------------------------------------------
+class FakeStdscr:
+    """Minimal fake curses screen that returns a scripted sequence of keys."""
+
+    def __init__(self, keys):
+        self._keys = list(keys)
+
+    def clear(self):
+        pass
+
+    def addstr(self, *args, **kwargs):
+        pass
+
+    def refresh(self):
+        pass
+
+    def getch(self):
+        if not self._keys:
+            # Safety net: quit if the script runs out.
+            return ord("q")
+        return self._keys.pop(0)
+
+
+class FakeCurses:
+    """Stand-in for the curses module used by the interactive mapper."""
+
+    KEY_UP = 1000
+    KEY_DOWN = 1001
+    KEY_LEFT = 1002
+    KEY_RIGHT = 1003
+    KEY_ENTER = 1004
+
+    def __init__(self, keys):
+        self._keys = keys
+
+    def curs_set(self, n):
+        pass
+
+    def wrapper(self, func):
+        return func(FakeStdscr(self._keys))
+
+
+def _install_fake_curses(monkeypatch, keys):
+    fake = FakeCurses(keys)
+    monkeypatch.setattr(mapping_mod, "curses", fake)
+    return fake
+
+
+def _interactive_session_df():
+    return pd.DataFrame(
+        [
+            {"Acquisition": "in_alpha", "ProtocolName": "ProtoAlpha"},
+            {"Acquisition": "in_beta", "ProtocolName": "ProtoBeta"},
+            # in_gamma intentionally has two distinct ProtocolNames -> "multiple"
+            {"Acquisition": "in_gamma", "ProtocolName": "ProtoG1"},
+            {"Acquisition": "in_gamma", "ProtocolName": "ProtoG2"},
+        ]
+    )
+
+
+def _interactive_ref_session():
+    return {
+        "acquisitions": {
+            "RefOne": {"fields": []},
+            "RefTwo": {"fields": []},
+        }
+    }
+
+
+class TestInteractiveMapping:
+    def test_map_first_ref_to_first_input(self, monkeypatch):
+        c = FakeCurses.__dict__  # keep reference alive
+        keys = [
+            FakeCurses.KEY_RIGHT,   # enter input-selection for RefOne (idx 0)
+            FakeCurses.KEY_ENTER,   # confirm in_alpha (input idx 0)
+            ord("q"),               # quit
+        ]
+        _install_fake_curses(monkeypatch, keys)
+        result = interactive_mapping_to_json_reference(
+            _interactive_session_df(), _interactive_ref_session()
+        )
+        # reference_acq_names sorted -> ["RefOne", "RefTwo"]; input sorted ->
+        # ["in_alpha", "in_beta", "in_gamma"]
+        assert result["RefOne"] == "in_alpha"
+
+    def test_navigation_and_unmap(self, monkeypatch):
+        keys = [
+            FakeCurses.KEY_DOWN,    # move ref selection to RefTwo (idx 1)
+            FakeCurses.KEY_UP,      # back to RefOne
+            FakeCurses.KEY_RIGHT,   # open input list
+            FakeCurses.KEY_DOWN,    # to in_beta
+            FakeCurses.KEY_DOWN,    # to in_gamma
+            FakeCurses.KEY_UP,      # back to in_beta
+            FakeCurses.KEY_LEFT,    # cancel selection (no assignment)
+            FakeCurses.KEY_RIGHT,   # reopen
+            FakeCurses.KEY_ENTER,   # confirm in_alpha for RefOne
+            ord("u"),               # unmap RefOne
+            ord("q"),
+        ]
+        _install_fake_curses(monkeypatch, keys)
+        result = interactive_mapping_to_json_reference(
+            _interactive_session_df(), _interactive_ref_session()
+        )
+        # RefOne was mapped then unmapped -> should be absent
+        assert "RefOne" not in result
+
+    def test_enter_without_input_selection_noop(self, monkeypatch):
+        keys = [
+            FakeCurses.KEY_ENTER,   # ENTER while not picking input -> no-op branch
+            ord("q"),
+        ]
+        _install_fake_curses(monkeypatch, keys)
+        result = interactive_mapping_to_json_reference(
+            _interactive_session_df(), _interactive_ref_session()
+        )
+        assert result == {}
+
+    def test_initial_mapping_seeded(self, monkeypatch):
+        keys = [ord("q")]
+        _install_fake_curses(monkeypatch, keys)
+        result = interactive_mapping_to_json_reference(
+            _interactive_session_df(),
+            _interactive_ref_session(),
+            initial_mapping={
+                "RefTwo": "in_beta",
+                "RefUnknown": "in_alpha",  # ignored: ref not in ref set
+                "RefOne": "no_such_input",  # ignored: input not present
+            },
+        )
+        assert result == {"RefTwo": "in_beta"}
+
+    def test_reassign_input(self, monkeypatch):
+        keys = [
+            FakeCurses.KEY_RIGHT,
+            FakeCurses.KEY_ENTER,   # RefOne -> in_alpha
+            FakeCurses.KEY_RIGHT,
+            FakeCurses.KEY_DOWN,    # to in_beta
+            FakeCurses.KEY_ENTER,   # RefOne -> in_beta (overwrite)
+            ord("q"),
+        ]
+        _install_fake_curses(monkeypatch, keys)
+        result = interactive_mapping_to_json_reference(
+            _interactive_session_df(), _interactive_ref_session()
+        )
+        assert result["RefOne"] == "in_beta"
+
+
+# ---------------------------------------------------------------------------
+# acquisition helper functions
+# ---------------------------------------------------------------------------
+class TestDicomTimeToSeconds:
+    def test_nan_returns_zero(self):
+        assert _dicom_time_to_seconds(np.nan) == 0
+
+    def test_empty_string_returns_zero(self):
+        assert _dicom_time_to_seconds("") == 0
+
+    def test_hhmmss_string(self):
+        # 01:02:03 -> 3723 seconds
+        assert _dicom_time_to_seconds("010203") == 3723
+
+    def test_fractional_seconds_stripped(self):
+        assert _dicom_time_to_seconds("010203.500000") == 3723
+
+    def test_short_string_padded(self):
+        # "0102" -> "010200" -> 01:02:00 = 3720
+        assert _dicom_time_to_seconds("0102") == 3720
+
+    def test_numeric_input_returned_as_float(self):
+        assert _dicom_time_to_seconds(42) == 42.0
+
+
+class TestNormalizeSeriesDescription:
+    def test_nan_passthrough(self):
+        assert pd.isna(_normalize_series_description_for_run_detection(np.nan))
+
+    def test_empty_passthrough(self):
+        assert _normalize_series_description_for_run_detection("") == ""
+
+    def test_single_rr_removed(self):
+        assert _normalize_series_description_for_run_detection("qsm_RR") == "qsm"
+
+    def test_multiple_rr_removed(self):
+        assert _normalize_series_description_for_run_detection("qsm_RR_RR") == "qsm"
+
+    def test_no_rr_unchanged(self):
+        assert _normalize_series_description_for_run_detection("qsm") == "qsm"
+
+
+# ---------------------------------------------------------------------------
+# acquisition.assign_acquisition_and_run_numbers
+# ---------------------------------------------------------------------------
+class TestAssignAcquisitionAndRunNumbers:
+    def test_existing_acquisition_column_short_circuit(self):
+        df = pd.DataFrame([{"Acquisition": "already", "ProtocolName": "p"}])
+        result = assign_acquisition_and_run_numbers(df)
+        assert list(result["Acquisition"]) == ["already"]
+
+    def test_raises_without_protocol_or_sequence(self):
+        df = pd.DataFrame([{"SeriesDescription": "foo"}])
+        with pytest.raises(ValueError, match="Neither ProtocolName nor SequenceName"):
+            assign_acquisition_and_run_numbers(df)
+
+    def test_single_acquisition_basic(self):
+        df = pd.DataFrame(
+            [
+                {"ProtocolName": "MyProto", "SeriesDescription": "sd", "ImageType": "M"},
+                {"ProtocolName": "MyProto", "SeriesDescription": "sd", "ImageType": "M"},
+            ]
+        )
+        result = assign_acquisition_and_run_numbers(df)
+        assert set(result["Acquisition"]) == {"acq-myproto"}
+        assert set(result["RunNumber"]) == {1}
+        assert "Series" in result.columns
+
+    def test_sequence_name_fallback(self):
+        # ProtocolName present but NaN -> falls back to SequenceName.
+        df = pd.DataFrame(
+            [
+                {"ProtocolName": np.nan, "SequenceName": "seqfoo", "SeriesDescription": "sd"},
+                {"ProtocolName": np.nan, "SequenceName": "seqfoo", "SeriesDescription": "sd"},
+            ]
+        )
+        result = assign_acquisition_and_run_numbers(df)
+        assert set(result["Acquisition"]) == {"acq-seqfoo"}
+
+    def test_sequence_name_only(self):
+        df = pd.DataFrame(
+            [
+                {"SequenceName": "seqonly", "SeriesDescription": "sd"},
+                {"SequenceName": "seqonly", "SeriesDescription": "sd"},
+            ]
+        )
+        result = assign_acquisition_and_run_numbers(df)
+        assert set(result["Acquisition"]) == {"acq-seqonly"}
+
+    def test_patient_name_only(self):
+        df = pd.DataFrame(
+            [
+                {"ProtocolName": "P", "PatientName": "Alice", "SeriesDescription": "sd"},
+                {"ProtocolName": "P", "PatientName": "Alice", "SeriesDescription": "sd"},
+            ]
+        )
+        result = assign_acquisition_and_run_numbers(df)
+        assert set(result["Acquisition"]) == {"acq-p"}
+
+    def test_patient_id_only(self):
+        df = pd.DataFrame(
+            [
+                {"ProtocolName": "P", "PatientID": "ID1", "SeriesDescription": "sd"},
+                {"ProtocolName": "P", "PatientID": "ID1", "SeriesDescription": "sd"},
+            ]
+        )
+        result = assign_acquisition_and_run_numbers(df)
+        assert set(result["Acquisition"]) == {"acq-p"}
+
+    def test_no_series_fields_default_signature(self):
+        # No SeriesDescription/ImageType/InversionTime columns -> "default" signature path.
+        df = pd.DataFrame(
+            [
+                {"ProtocolName": "NoSeries", "Foo": 1},
+                {"ProtocolName": "NoSeries", "Foo": 2},
+            ]
+        )
+        result = assign_acquisition_and_run_numbers(df)
+        assert set(result["Acquisition"]) == {"acq-noseries"}
+        assert set(result["Series"]) == {"Series 01"}
+
+    def test_multiple_runs_detected_via_series_time(self):
+        # Two runs of the same series, >60s apart -> two runs.
+        rows = []
+        for run_idx, (stime, uid) in enumerate(
+            [("100000.000000", "uid-run1"), ("100200.000000", "uid-run2")]
+        ):
+            for _ in range(2):
+                rows.append(
+                    {
+                        "ProtocolName": "RunProto",
+                        "PatientName": "Pat",
+                        "PatientID": "PID",
+                        "SeriesDescription": "sd",
+                        "ImageType": "M",
+                        "SeriesInstanceUID": uid,
+                        "SeriesTime": stime,
+                    }
+                )
+        df = pd.DataFrame(rows)
+        result = assign_acquisition_and_run_numbers(df)
+        assert set(result["RunNumber"]) == {1, 2}
+
+    def test_acquisition_time_fallback_for_runs(self):
+        # No SeriesTime, but AcquisitionTime present -> uses AcquisitionTime (line 222-223).
+        rows = []
+        for stime, uid in [("100000.000000", "uidA"), ("100200.000000", "uidB")]:
+            for _ in range(2):
+                rows.append(
+                    {
+                        "ProtocolName": "AcqTimeProto",
+                        "PatientName": "Pat",
+                        "PatientID": "PID",
+                        "SeriesDescription": "sd",
+                        "ImageType": "M",
+                        "SeriesInstanceUID": uid,
+                        "AcquisitionTime": stime,
+                    }
+                )
+        df = pd.DataFrame(rows)
+        result = assign_acquisition_and_run_numbers(df)
+        assert set(result["RunNumber"]) == {1, 2}
+
+    def test_settings_split_creates_second_acquisition(self):
+        # Same protocol, two temporally-separated runs, but a settings field
+        # (EchoTime) changes between them -> acquisition split (Stage 4).
+        rows = []
+        for etime, stime, uid in [
+            (10.0, "100000.000000", "uidA"),
+            (20.0, "100200.000000", "uidB"),
+        ]:
+            for _ in range(2):
+                rows.append(
+                    {
+                        "ProtocolName": "SplitProto",
+                        "PatientName": "Pat",
+                        "PatientID": "PID",
+                        "SeriesDescription": "sd",
+                        "ImageType": "M",
+                        "EchoTime": etime,
+                        "SeriesInstanceUID": uid,
+                        "SeriesTime": stime,
+                    }
+                )
+        df = pd.DataFrame(rows)
+        result = assign_acquisition_and_run_numbers(df)
+        acqs = set(result["Acquisition"])
+        # Original acq plus a settings-split acquisition suffixed with _2
+        assert "acq-splitproto" in acqs
+        assert any(a.endswith("_2") for a in acqs)
+
+    def test_orphan_series_assigned_to_closest_run(self):
+        # One repeated series (drives run detection) plus an orphan series with
+        # its own SeriesTime -> orphan is assigned to the closest run by time
+        # (lines 333-367).
+        rows = []
+        # Repeated series: two UIDs >60s apart -> two runs
+        for stime, uid in [("100000.000000", "rep-uid1"), ("100300.000000", "rep-uid2")]:
+            rows.append(
+                {
+                    "ProtocolName": "OrphanProto",
+                    "PatientName": "Pat",
+                    "PatientID": "PID",
+                    "SeriesDescription": "repeated",
+                    "ImageType": "M",
+                    "SeriesInstanceUID": uid,
+                    "SeriesTime": stime,
+                }
+            )
+        # Orphan series (single UID) near run 2's time
+        rows.append(
+            {
+                "ProtocolName": "OrphanProto",
+                "PatientName": "Pat",
+                "PatientID": "PID",
+                "SeriesDescription": "orphan",
+                "ImageType": "P",
+                "SeriesInstanceUID": "orphan-uid",
+                "SeriesTime": "100305.000000",
+            }
+        )
+        df = pd.DataFrame(rows)
+        result = assign_acquisition_and_run_numbers(df)
+        orphan_rows = result[result["SeriesDescription"] == "orphan"]
+        # The orphan-series branch (closest-run-by-time) executed and assigned a
+        # concrete run number to the orphan series.
+        assert len(orphan_rows) == 1
+        assert orphan_rows["RunNumber"].iloc[0] in (1, 2)
+        assert orphan_rows["Acquisition"].iloc[0].startswith("acq-orphanproto")
+
+    def test_orphan_series_without_time_assigned_run_one(self):
+        # Orphan series whose SeriesTime is missing -> defaults to run 1 (lines 338-346).
+        rows = []
+        for stime, uid in [("100000.000000", "rep1"), ("100300.000000", "rep2")]:
+            rows.append(
+                {
+                    "ProtocolName": "OrphanNoTime",
+                    "PatientName": "Pat",
+                    "PatientID": "PID",
+                    "SeriesDescription": "repeated",
+                    "ImageType": "M",
+                    "SeriesInstanceUID": uid,
+                    "SeriesTime": stime,
+                }
+            )
+        # Orphan with no SeriesTime value
+        rows.append(
+            {
+                "ProtocolName": "OrphanNoTime",
+                "PatientName": "Pat",
+                "PatientID": "PID",
+                "SeriesDescription": "orphan",
+                "ImageType": "P",
+                "SeriesInstanceUID": "orphan-uid",
+                "SeriesTime": np.nan,
+            }
+        )
+        df = pd.DataFrame(rows)
+        result = assign_acquisition_and_run_numbers(df)
+        orphan_rows = result[result["SeriesDescription"] == "orphan"]
+        assert set(orphan_rows["RunNumber"]) == {1}
+
+
+# ---------------------------------------------------------------------------
+# data_utils.make_dataframe_hashable
+# ---------------------------------------------------------------------------
+class TestMakeDataframeHashable:
+    def test_lists_become_tuples(self):
+        df = pd.DataFrame({"a": [[1, 2], [3, 4]]})
+        out = make_dataframe_hashable(df)
+        assert out["a"].iloc[0] == (1, 2)
+        assert out["a"].iloc[1] == (3, 4)
+
+    def test_nested_lists(self):
+        df = pd.DataFrame({"a": [[[1], [2]]]})
+        out = make_dataframe_hashable(df)
+        assert out["a"].iloc[0] == ((1,), (2,))
+
+    def test_scalars_unchanged(self):
+        df = pd.DataFrame({"a": [1, "x"]})
+        out = make_dataframe_hashable(df)
+        assert list(out["a"]) == [1, "x"]
+
+    def test_all_values_hashable_after(self):
+        df = pd.DataFrame({"a": [[1, 2], {"k": "v"}]})
+        out = make_dataframe_hashable(df)
+        for v in out["a"]:
+            hash(v)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# data_utils._flatten_nested_dict / _reduce_flattened_keys
+# ---------------------------------------------------------------------------
+class TestFlattenNestedDict:
+    def test_simple_dict(self):
+        assert _flatten_nested_dict({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+
+    def test_nested_dict(self):
+        assert _flatten_nested_dict({"a": {"b": 1}}) == {"a_b": 1}
+
+    def test_list_of_primitives_kept_whole(self):
+        assert _flatten_nested_dict({"a": [1, 2, 3]}) == {"a": [1, 2, 3]}
+
+    def test_list_of_dicts_descended(self):
+        result = _flatten_nested_dict({"a": [{"b": 1}, {"c": 2}]})
+        assert result == {"a_0_b": 1, "a_1_c": 2}
+
+    def test_list_mixed_dict_and_primitive(self):
+        # Covers line 59: a non-dict item inside a dict-containing list.
+        result = _flatten_nested_dict({"a": [{"b": 1}, 42]})
+        assert result == {"a_0_b": 1, "a_1": 42}
+
+    def test_top_level_list_of_primitives(self):
+        # Covers the top-level list branch (lines 67-77).
+        assert _flatten_nested_dict([1, 2, 3]) == {"": [1, 2, 3]}
+
+    def test_top_level_list_of_dicts(self):
+        result = _flatten_nested_dict([{"a": 1}, {"b": 2}])
+        assert result == {"0_a": 1, "1_b": 2}
+
+    def test_top_level_list_mixed(self):
+        result = _flatten_nested_dict([{"a": 1}, 99])
+        assert result == {"0_a": 1, "1": 99}
+
+    def test_top_level_scalar(self):
+        assert _flatten_nested_dict(5) == {"": 5}
+
+
+class TestReduceFlattenedKeys:
+    def test_reduces_to_last_component(self):
+        assert _reduce_flattened_keys({"a_b_c": 1}) == {"c": 1}
+
+    def test_collision_keeps_first_non_none(self):
+        # Existing None, incoming value -> update.
+        result = _reduce_flattened_keys({"x_c": None, "y_c": 5})
+        assert result == {"c": 5}
+
+    def test_collision_keeps_existing_when_incoming_none(self):
+        result = _reduce_flattened_keys({"x_c": 5, "y_c": None})
+        assert result == {"c": 5}
+
+
+class TestConvertToPlainPythonTypes:
+    def test_float_rounded(self):
+        assert _convert_to_plain_python_types(1.123456789) == round(1.123456789, 5)
+
+    def test_int_preserved(self):
+        assert _convert_to_plain_python_types(np.int64(7)) == 7
+
+    def test_list_recursed(self):
+        assert _convert_to_plain_python_types([1.0000001, 2]) == [1.0, 2]
+
+    def test_dict_recursed(self):
+        assert _convert_to_plain_python_types({"a": 1.0000001}) == {"a": 1.0}
+
+    def test_string_passthrough(self):
+        assert _convert_to_plain_python_types("hello") == "hello"
+
+
+class TestProcessDicomMetadata:
+    def test_enhanced_to_regular_mapping_applied(self):
+        # EffectiveEchoTime -> EchoTime when EchoTime absent.
+        result = _process_dicom_metadata({"EffectiveEchoTime": 2.5})
+        assert result.get("EchoTime") == 2.5
+        assert "EffectiveEchoTime" not in result
+
+    def test_enhanced_empty_source_removed(self):
+        # Source empty but target has a value -> source removed, target kept.
+        result = _process_dicom_metadata({"EffectiveEchoTime": "", "EchoTime": 3.0})
+        assert result.get("EchoTime") == 3.0
+        assert "EffectiveEchoTime" not in result
+
+    def test_acquisition_datetime_split(self):
+        # AcquisitionDateTime split into date + time (lines 188-196).
+        result = _process_dicom_metadata({"AcquisitionDateTime": "20250101123456.000000"})
+        assert result["AcquisitionDate"] == "20250101"
+        assert result["AcquisitionTime"] == "123456.000000"
+
+    def test_acquisition_datetime_no_time_component(self):
+        # Exactly 8 chars -> date set, time None.
+        result = _process_dicom_metadata({"AcquisitionDateTime": "20250101"})
+        assert result["AcquisitionDate"] == "20250101"
+        assert result["AcquisitionTime"] is None
+
+    def test_acquisition_datetime_not_split_when_fields_present(self):
+        result = _process_dicom_metadata(
+            {
+                "AcquisitionDateTime": "20250101123456",
+                "AcquisitionDate": "19990101",
+                "AcquisitionTime": "010101",
+            }
+        )
+        assert result["AcquisitionDate"] == "19990101"
+        assert result["AcquisitionTime"] == "010101"
+
+
+class TestPrepareSessionDataframe:
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="No session data"):
+            prepare_session_dataframe([])
+
+    def test_sorts_by_instance_number(self):
+        data = [
+            {"InstanceNumber": 3, "Val": "c"},
+            {"InstanceNumber": 1, "Val": "a"},
+            {"InstanceNumber": 2, "Val": "b"},
+        ]
+        df = prepare_session_dataframe(data)
+        assert list(df["InstanceNumber"]) == [1, 2, 3]
+
+    def test_sorts_by_dicom_path_when_no_instance_number(self):
+        data = [
+            {"DICOM_Path": "/z", "Val": 1},
+            {"DICOM_Path": "/a", "Val": 2},
+        ]
+        df = prepare_session_dataframe(data)
+        assert list(df["DICOM_Path"]) == ["/a", "/z"]
+
+    def test_drops_all_nan_columns(self):
+        data = [
+            {"Keep": 1, "Empty": None},
+            {"Keep": 2, "Empty": None},
+        ]
+        df = prepare_session_dataframe(data)
+        assert "Keep" in df.columns
+        assert "Empty" not in df.columns
+
+    def test_lists_made_hashable(self):
+        data = [{"ImageType": ["ORIGINAL", "PRIMARY"], "InstanceNumber": 1}]
+        df = prepare_session_dataframe(data)
+        assert df["ImageType"].iloc[0] == ("ORIGINAL", "PRIMARY")

--- a/dicompare/tests/test_small_modules_coverage.py
+++ b/dicompare/tests/test_small_modules_coverage.py
@@ -361,7 +361,7 @@ def test_check_acquisition_compliance_series_min_only_and_contains_any():
             {"name": "MinOnly", "fields": [{"field": "EchoTime", "min": 100}]},
             {"name": "MaxOnly", "fields": [{"field": "EchoTime", "max": -1}]},
             {"name": "AnyS", "fields": [{"field": "ImageType", "contains_any": ["FOO", "BAR"]}]},
-            {"name": "AllS", "fields": [{"field": "ImageType", "contains_all": ["FOO", "BAR"]}]},
+            {"name": "AllOf", "fields": [{"field": "ImageType", "contains_all": ["FOO", "BAR"]}]},
         ]
     }
     results = check_acquisition_compliance(df, schema, acquisition_name="A")
@@ -369,7 +369,7 @@ def test_check_acquisition_compliance_series_min_only_and_contains_any():
     assert ">= 100" in msgs["MinOnly"]
     assert "<= -1" in msgs["MaxOnly"]
     assert "contains any of" in msgs["AnyS"]
-    assert "contains all of" in msgs["AllS"]
+    assert "contains all of" in msgs["AllOf"]
 
 
 def test_check_acquisition_compliance_validation_model_class_instantiated():

--- a/dicompare/tests/test_small_modules_coverage.py
+++ b/dicompare/tests/test_small_modules_coverage.py
@@ -1,0 +1,606 @@
+"""
+Targeted unit tests to top up coverage of several smaller dicompare modules.
+
+Covers edge cases / error paths in:
+  - dicompare/io/dicom_generator.py
+  - dicompare/schema/tags.py
+  - dicompare/io/printprot.py
+  - dicompare/validation/compliance.py
+  - dicompare/io/special_fields.py
+  - dicompare/io/gradients.py
+  - dicompare/validation/helpers.py
+  - dicompare/schemas/__init__.py
+  - dicompare/schema/build_schema.py
+"""
+
+import io
+import json
+import zipfile
+
+import pandas as pd
+import pydicom
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# dicompare/io/dicom_generator.py
+# ---------------------------------------------------------------------------
+from dicompare.io import generate_test_dicoms_from_schema
+
+
+def _read_first_dicom(zip_bytes):
+    with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
+        names = sorted(zf.namelist())
+        return [pydicom.dcmread(io.BytesIO(zf.read(n))) for n in names]
+
+
+def test_dicom_generator_invalid_tag_is_skipped(capsys):
+    """A malformed tag string is skipped (hits the except branch)."""
+    test_data = [{"BadField": 5, "RepetitionTime": 2000}]
+    field_definitions = [
+        {"name": "BadField", "tag": "notahex,zz", "vr": "DS"},
+        {"name": "RepetitionTime", "tag": "0018,0080", "vr": "DS"},
+    ]
+    zip_bytes = generate_test_dicoms_from_schema(test_data, field_definitions)
+    ds = _read_first_dicom(zip_bytes)[0]
+    assert str(ds.RepetitionTime) == "2000.0"
+    out = capsys.readouterr().out
+    assert "Skipping invalid tag" in out
+
+
+def test_dicom_generator_series_grouping_shares_uid():
+    """Rows with the same _seriesIndex share a SeriesInstanceUID and series name."""
+    test_data = [
+        {"_seriesIndex": 0, "_seriesName": "SeriesA", "RepetitionTime": 2000},
+        {"_seriesIndex": 0, "_seriesName": "SeriesA", "RepetitionTime": 2000},
+        {"_seriesIndex": 1, "_seriesName": "SeriesB", "RepetitionTime": 3000},
+    ]
+    field_definitions = [{"name": "RepetitionTime", "tag": "0018,0080", "vr": "DS"}]
+    zip_bytes = generate_test_dicoms_from_schema(test_data, field_definitions)
+    dss = _read_first_dicom(zip_bytes)
+    assert dss[0].SeriesInstanceUID == dss[1].SeriesInstanceUID
+    assert dss[0].SeriesInstanceUID != dss[2].SeriesInstanceUID
+    assert dss[0].SeriesDescription == "SeriesA"
+    assert dss[2].SeriesDescription == "SeriesB"
+
+
+def test_dicom_generator_vr_numeric_variants():
+    """Exercise DS/IS/FL/FD/US single-value and list conversions across VR types."""
+    test_data = [
+        {
+            "InstanceNumber": 7,                              # IS single
+            "ImageOrientationPatient": [1, 0, 0, 0, 1, 0],   # DS list of ints
+            "AcquisitionMatrix": [64, 64],                   # US list -> integers
+            "AcquisitionNumber": [1, 2],                     # IS list -> string list
+            "TableHeight": 155.5,                            # DS single
+        }
+    ]
+    field_definitions = [
+        {"name": "InstanceNumber", "tag": "0020,0013", "vr": "IS"},
+        {"name": "ImageOrientationPatient", "tag": "0020,0037", "vr": "DS"},
+        {"name": "AcquisitionMatrix", "tag": "0018,1310", "vr": "US"},
+        {"name": "AcquisitionNumber", "tag": "0020,0012", "vr": "IS"},
+        {"name": "TableHeight", "tag": "0018,1130", "vr": "DS"},
+    ]
+    zip_bytes = generate_test_dicoms_from_schema(test_data, field_definitions)
+    ds = _read_first_dicom(zip_bytes)[0]
+    assert list(ds.AcquisitionMatrix) == [64, 64]
+    assert int(ds.InstanceNumber) == 7
+    assert len(ds.ImageOrientationPatient) == 6
+
+
+def test_dicom_generator_float_vr_single_and_list():
+    """FL/FD VR types keep numeric single values and lists (lines 229, 243)."""
+    test_data = [
+        {
+            "DiffusionBValue": 1000.0,                       # FD single -> float
+            "DiffusionGradientOrientation": [1.0, 0.0, 0.0],  # FD list -> floats
+        }
+    ]
+    field_definitions = [
+        {"name": "DiffusionBValue", "tag": "0018,9087", "vr": "FD"},
+        {"name": "DiffusionGradientOrientation", "tag": "0018,9089", "vr": "FD"},
+    ]
+    zip_bytes = generate_test_dicoms_from_schema(test_data, field_definitions)
+    ds = _read_first_dicom(zip_bytes)[0]
+    assert float(ds.DiffusionBValue) == 1000.0
+    assert list(ds.DiffusionGradientOrientation) == [1.0, 0.0, 0.0]
+
+
+def test_dicom_generator_string_field_and_none():
+    """String VR fields and a None value take the string branches."""
+    test_data = [{"SequenceName": "epfid2d1_64", "PatientPosition": None}]
+    field_definitions = [
+        {"name": "SequenceName", "tag": "0018,0024", "vr": "SH"},
+        {"name": "PatientPosition", "tag": "0018,5100", "vr": "CS"},
+    ]
+    zip_bytes = generate_test_dicoms_from_schema(test_data, field_definitions)
+    ds = _read_first_dicom(zip_bytes)[0]
+    assert ds.SequenceName == "epfid2d1_64"
+
+
+def test_dicom_generator_uncastable_value_is_caught(capsys):
+    """A value that cannot be cast for its VR is caught and skipped (except branch)."""
+    # RepetitionTime is DS; a non-numeric string triggers float() failure inside the
+    # try block -> caught, warning printed, generation still succeeds.
+    test_data = [{"RepetitionTime": ["not_a_number"], "EchoTime": 2.46}]
+    field_definitions = [
+        {"name": "RepetitionTime", "tag": "0018,0080", "vr": "DS"},
+        {"name": "EchoTime", "tag": "0018,0081", "vr": "DS"},
+    ]
+    zip_bytes = generate_test_dicoms_from_schema(test_data, field_definitions)
+    ds = _read_first_dicom(zip_bytes)[0]
+    assert str(ds.EchoTime) == "2.46"
+    assert "Could not set RepetitionTime" in capsys.readouterr().out
+
+
+def test_dicom_generator_special_multiband_field():
+    """A handled special field (MultibandFactor) is encoded and sets Manufacturer."""
+    test_data = [{"MultibandFactor": 3, "RepetitionTime": 2000}]
+    field_definitions = [
+        {"name": "MultibandFactor", "tag": ""},
+        {"name": "RepetitionTime", "tag": "0018,0080", "vr": "DS"},
+    ]
+    zip_bytes = generate_test_dicoms_from_schema(test_data, field_definitions)
+    ds = _read_first_dicom(zip_bytes)[0]
+    assert ds.ImageComments == "Unaliased MB3/PE2"
+    assert ds.Manufacturer == "SIEMENS"
+
+
+def test_dicom_generator_unknown_tag_frontend_vr_fallback():
+    """A valid-format tag unknown to pydicom falls back to the frontend VR (except branch)."""
+    test_data = [{"MyPrivate": 5}]
+    # (0011,1010) is not a standard keyword -> dictionary_VR raises KeyError and
+    # actual_vr falls back to the frontend VR ('US'); generation still succeeds.
+    field_definitions = [{"name": "MyPrivate", "tag": "0011,1010", "vr": "US"}]
+    zip_bytes = generate_test_dicoms_from_schema(test_data, field_definitions)
+    dss = _read_first_dicom(zip_bytes)
+    assert len(dss) == 1  # DICOM generated without error
+
+
+# ---------------------------------------------------------------------------
+# dicompare/io/special_fields.py
+# ---------------------------------------------------------------------------
+from dicompare.io.special_fields import (
+    categorize_field,
+    apply_special_field_encoding,
+    encode_multiband_in_image_comments,
+)
+
+
+def test_categorize_field_valid_format_unknown_tag_is_standard():
+    """A valid-format tag (even one pydicom cannot name) is categorized as standard."""
+    category, _desc = categorize_field("SomeField", "0011,1010")
+    assert category == "standard"
+
+
+def test_categorize_field_invalid_tag_falls_through():
+    """A tag with a comma but non-hex parts hits the ValueError branch and falls through."""
+    # Not a handled special field and not a valid tag -> unhandled.
+    category, desc = categorize_field("WeirdField", "zz,zz")
+    assert category == "unhandled"
+
+
+def test_apply_special_field_encoding_leak_block():
+    """LeakBlock=True appends /LB to the ImageComments encoding."""
+    ds = pydicom.Dataset()
+    apply_special_field_encoding(ds, {"MultibandFactor": 4, "PhaseEncodingShift": 3, "LeakBlock": True})
+    assert ds.ImageComments == "Unaliased MB4/PE3/LB"
+
+
+def test_encode_multiband_singleband_reference():
+    """MB factor <= 1 yields a single-band reference string."""
+    assert encode_multiband_in_image_comments(1) == "Single-band reference SENSE1"
+
+
+# ---------------------------------------------------------------------------
+# dicompare/schema/tags.py
+# ---------------------------------------------------------------------------
+from dicompare.schema.tags import get_tag_info, determine_field_type_from_values
+
+
+def test_get_tag_info_known_tag_format_infers_type():
+    """A known standard tag in (gggg,eeee) format returns its inferred type + name."""
+    info = get_tag_info("(0018,0080)")  # RepetitionTime, DS -> number
+    assert info["tag"] == "(0018,0080)"
+    assert info["type"] == "number"
+    assert info["fieldType"] == "standard"
+    assert info["name"]  # description present
+
+
+def test_get_tag_info_field_with_underscores():
+    """A keyword with underscores resolves via the underscore-stripping fallback."""
+    info = get_tag_info("Repetition_Time")
+    assert info["tag"] == "(0018,0080)"
+    assert info["fieldType"] == "standard"
+
+
+def test_get_tag_info_field_with_spaces():
+    """A keyword with spaces resolves via the space-stripping fallback."""
+    info = get_tag_info("Flip Angle")
+    assert info["tag"] == "(0018,1314)"
+    assert info["fieldType"] == "standard"
+
+
+def test_determine_field_type_from_plain_list_input():
+    """A plain (non-pandas) list of multi-valued items becomes list_*."""
+    result = determine_field_type_from_values("PatientName", [["A", "B"], None])
+    assert result == "list_string"
+
+
+def test_determine_field_type_from_tuple_values():
+    """Tuple values are detected as multi-valued."""
+    result = determine_field_type_from_values("PixelSpacing", [(0.5, 0.5), (0.6, 0.6)])
+    assert result == "list_number"
+
+
+def test_determine_field_type_backslash_string_scalar_field():
+    """A scalar-typed field with backslash-joined string values becomes list_string."""
+    # SeriesDescription is VR=LO, VM=1 -> base type 'string'; backslash promotes it.
+    result = determine_field_type_from_values("SeriesDescription", ["a\\b", "c\\d"])
+    assert result == "list_string"
+
+
+# ---------------------------------------------------------------------------
+# dicompare/io/gradients.py
+# ---------------------------------------------------------------------------
+from dicompare.io.gradients import (
+    parse_bvec,
+    descriptors_from_dvs,
+    descriptors_from_bvec_bval,
+    _hemisphere_coverage,
+)
+
+
+def test_parse_bvec_inconsistent_row_lengths():
+    with pytest.raises(ValueError, match="inconsistent"):
+        parse_bvec("1 0\n0 1 0\n0 0 1")
+
+
+def test_descriptors_from_dvs_no_vectors():
+    with pytest.raises(ValueError, match="No vectors"):
+        descriptors_from_dvs("[directions=0]\nNormalisation = none\n", b_max=1000)
+
+
+def test_descriptors_from_bvec_bval_length_mismatch():
+    bvec = "0 1\n0 0\n0 0"  # 2 dirs
+    bval = "0 1000 1000"     # 3 bvals
+    with pytest.raises(ValueError, match="length mismatch"):
+        descriptors_from_bvec_bval(bvec, bval)
+
+
+def test_hemisphere_coverage_too_few_directions():
+    """Fewer than 2 non-b0 directions returns 'unknown'."""
+    result = _hemisphere_coverage([(1.0, 0.0, 0.0)], [1000.0])
+    assert result == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# dicompare/validation/helpers.py
+# ---------------------------------------------------------------------------
+from dicompare.validation.helpers import check_equality, validate_constraint, validate_field_values
+
+
+def test_check_equality_nested_list_numeric_and_string_normalization():
+    """List inputs recurse: numeric strings convert, non-numeric strings normalize."""
+    # Both are lists so we bypass the str-branch and hit normalize_for_comparison.
+    assert check_equality(["42"], [42]) is True          # numeric conversion (line 85)
+    assert check_equality(["Abc"], ["abc"]) is True       # string normalization (line 89)
+
+
+def test_validate_constraint_list_expected_non_list_actual():
+    """Expected is a list but actual is scalar -> constraint fails."""
+    assert validate_constraint(5, expected_value=[5, 6]) is False
+
+
+def test_validate_field_values_whole_list_mismatch():
+    """Multi-element actual_values compared against an expected list that differs."""
+    passed, invalid, message = validate_field_values(
+        "ImageType", ["ORIGINAL", "PRIMARY"], expected_value=["ORIGINAL", "SECONDARY"]
+    )
+    assert passed is False
+    assert "Expected" in message
+
+
+# ---------------------------------------------------------------------------
+# dicompare/validation/compliance.py
+# ---------------------------------------------------------------------------
+from dicompare.validation.compliance import check_acquisition_compliance, _find_column_match
+
+
+def test_find_column_match_normalizations():
+    cols = ["FlipAngle", "EchoTime", "FooBar"]
+    assert _find_column_match("Flip Angle", cols) == "FlipAngle"   # no-space
+    assert _find_column_match("Foo_Bar", cols) == "FooBar"         # no-underscore (line 40)
+    assert _find_column_match("echotime", cols) == "EchoTime"      # case-insensitive
+    assert _find_column_match("flip_angle", cols) == "FlipAngle"   # normalized
+    assert _find_column_match("Missing", cols) is None
+
+
+def test_check_acquisition_compliance_requires_acquisition_column():
+    df = pd.DataFrame({"EchoTime": [1.0]})
+    with pytest.raises(ValueError, match="Acquisition"):
+        check_acquisition_compliance(df, {"fields": []}, acquisition_name="T1")
+
+
+def test_check_acquisition_compliance_no_name_uses_full_session():
+    """With no acquisition_name the whole session is used (else branch)."""
+    df = pd.DataFrame({"EchoTime": [2.46, 2.46]})
+    schema = {"fields": [{"field": "EchoTime", "value": 2.46}]}
+    results = check_acquisition_compliance(df, schema)
+    assert any(r["field"] == "EchoTime" for r in results)
+
+
+def test_check_acquisition_compliance_series_empty_fields_skipped():
+    """A series definition with no fields is skipped (continue branch)."""
+    df = pd.DataFrame({"Acquisition": ["A"], "EchoTime": [2.46]})
+    schema = {"series": [{"name": "S1", "fields": []}]}
+    results = check_acquisition_compliance(df, schema, acquisition_name="A")
+    # No series record produced for the empty-field series.
+    assert all(r.get("series") != "S1" for r in results)
+
+
+def test_check_acquisition_compliance_series_minmax_constraint_message():
+    """Series not matching a min/max constraint produces a descriptive message."""
+    df = pd.DataFrame({"Acquisition": ["A", "A"], "EchoTime": [2.0, 3.0]})
+    schema = {
+        "series": [
+            {"name": "S1", "fields": [{"field": "EchoTime", "min": 10, "max": 20}]},
+        ]
+    }
+    results = check_acquisition_compliance(df, schema, acquisition_name="A")
+    s1 = [r for r in results if r.get("series") == "S1"][0]
+    assert "in [10, 20]" in s1["message"]
+
+
+def test_check_acquisition_compliance_series_min_only_and_contains_any():
+    """Cover 'field >= min' and contains_any/contains_all constraint descriptions."""
+    df = pd.DataFrame({"Acquisition": ["A"], "EchoTime": [2.0], "ImageType": [["M"]]})
+    schema = {
+        "series": [
+            {"name": "MinOnly", "fields": [{"field": "EchoTime", "min": 100}]},
+            {"name": "MaxOnly", "fields": [{"field": "EchoTime", "max": -1}]},
+            {"name": "AnyS", "fields": [{"field": "ImageType", "contains_any": ["FOO", "BAR"]}]},
+            {"name": "AllS", "fields": [{"field": "ImageType", "contains_all": ["FOO", "BAR"]}]},
+        ]
+    }
+    results = check_acquisition_compliance(df, schema, acquisition_name="A")
+    msgs = {r.get("series"): r["message"] for r in results if r.get("series")}
+    assert ">= 100" in msgs["MinOnly"]
+    assert "<= -1" in msgs["MaxOnly"]
+    assert "contains any of" in msgs["AnyS"]
+    assert "contains all of" in msgs["AllS"]
+
+
+def test_check_acquisition_compliance_validation_model_class_instantiated():
+    """A model passed as a class (not instance) is instantiated (line 302-303)."""
+    from dicompare.validation.core import BaseValidationModel, validator
+
+    class MyModel(BaseValidationModel):
+        @validator(["EchoTime"], rule_name="echo", rule_message="Echo present")
+        def check_echo(cls, value):
+            return value
+
+    df = pd.DataFrame({"Acquisition": ["A"], "EchoTime": [2.46]})
+    results = check_acquisition_compliance(
+        df, {"fields": []}, acquisition_name="A", validation_model=MyModel
+    )
+    assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# dicompare/io/printprot.py
+# ---------------------------------------------------------------------------
+from dicompare.io.printprot import (
+    _split_value_unit,
+    _parse_header_title,
+    apply_printprot_to_dicom_mapping,
+    _extract_series_parameters,
+    _generate_series_combinations,
+    _read_content,
+    load_printprot_file,
+    load_printprot_file_schema_format,
+)
+
+
+def test_split_value_unit_multi_number_treated_as_string():
+    """A leading number followed by more digits is kept as a string (unit has digits)."""
+    val, unit = _split_value_unit("2 x 2")
+    assert val == "2 x 2"
+    assert unit is None
+
+
+def test_split_value_unit_plain_string():
+    val, unit = _split_value_unit("A >> P")
+    assert val == "A >> P"
+    assert unit is None
+
+
+def test_parse_header_title_empty():
+    assert _parse_header_title("") == {}
+
+
+def test_apply_mapping_multiple_bvalues_creates_series():
+    """Multiple distinct b-values become a list and generate series combinations."""
+    protocol = {
+        "name": "diff",
+        "title": "SIEMENS MAGNETOM ConnectomA syngo MR D11",
+        "params": {
+            ("Diff", "b-value 1"): "1000",
+            ("Diff", "b-value 2"): "2000",
+            ("Diff", "FoV read"): "220 mm",  # exercises other-field path in sort
+        },
+    }
+    fields = apply_printprot_to_dicom_mapping(protocol)
+    assert fields["DiffusionBValue"] == [1000, 2000]
+
+    series_params = _extract_series_parameters(fields)
+    assert series_params["DiffusionBValue"] == [1000, 2000]
+    series = _generate_series_combinations(series_params)
+    assert len(series) == 2
+    assert series[0]["name"] == "Series 01"
+    assert series[0]["fields"][0]["field"] == "DiffusionBValue"
+
+
+def test_generate_series_combinations_empty():
+    assert _generate_series_combinations({}) == []
+
+
+def test_sort_output_fields_orders_known_other_derived():
+    """A field not in DICOM_FIELD_ORDER and not derived goes to the 'other' bucket."""
+    from dicompare.io.printprot import _sort_output_fields
+
+    fields = {
+        "SomeCustomField": 1,     # other (line 405)
+        "RepetitionTime": 3900,    # known ordered
+        "MultibandFactor": 2,      # derived (last)
+    }
+    ordered = list(_sort_output_fields(fields).keys())
+    assert ordered.index("RepetitionTime") < ordered.index("SomeCustomField")
+    assert ordered.index("SomeCustomField") < ordered.index("MultibandFactor")
+
+
+def test_convert_to_schema_format_skips_series_and_empty():
+    """Fields that are series-varying or None/empty are excluded from acquisition fields."""
+    from dicompare.io.printprot import _convert_to_schema_format
+
+    dicom_fields = {
+        "RepetitionTime": 3900,
+        "EchoTime": None,               # skipped (line 458)
+        "ProtocolName": "",             # skipped (line 458)
+        "DiffusionBValue": [1000, 2000],  # series-varying -> skipped (line 456)
+    }
+    schema = _convert_to_schema_format(dicom_fields, "prot", "/tmp/x.txt")
+    field_names = {f["field"] for f in schema["fields"]}
+    assert field_names == {"RepetitionTime"}
+    assert len(schema["series"]) == 2
+
+
+def test_read_content_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError, match="not found"):
+        _read_content(tmp_path / "nope.txt")
+
+
+def test_read_content_latin1_fallback(tmp_path):
+    """Non-UTF-8 bytes are decoded with latin-1."""
+    p = tmp_path / "prot.txt"
+    p.write_bytes(b"Voxel 0.5\xd7\xd7 mm")  # 0xd7 invalid as UTF-8 start byte here
+    text = _read_content(p)
+    assert "Voxel" in text
+
+
+def test_load_printprot_txt_fixture():
+    """Load the real TXT fixture end-to-end."""
+    import dicompare.tests.fixtures as fx_pkg
+    from pathlib import Path
+
+    base = Path(fx_pkg.__file__).parent / "printprot"
+    results = load_printprot_file(base / "AxonDiameterProtocol.txt")
+    assert isinstance(results, list) and len(results) > 0
+    assert all("protocol_name" in r and "fields" in r for r in results)
+
+
+def test_load_printprot_xml_fixture_schema_format():
+    """Load the real XML fixture into schema format."""
+    import dicompare.tests.fixtures as fx_pkg
+    from pathlib import Path
+
+    base = Path(fx_pkg.__file__).parent / "printprot"
+    results = load_printprot_file_schema_format(base / "axcal_forJelle.xml")
+    assert isinstance(results, list) and len(results) > 0
+    for r in results:
+        assert "acquisition_info" in r
+        assert r["acquisition_info"]["source_type"] == "printprot"
+
+
+def test_parse_printprot_xml_name_fallback_to_title():
+    """When no HeaderProtPath is present, the protocol name falls back to the title."""
+    from dicompare.io.printprot import _parse_printprot_xml
+
+    xml = (
+        "<PrintOut><PrintProtocol><Protocol>"
+        "<HeaderTitle>SIEMENS MAGNETOM ConnectomA syngo MR D11</HeaderTitle>"
+        "<Card name='Routine'>"
+        "<ProtParameter><Label>TR</Label><ValueAndUnit>3900 ms</ValueAndUnit></ProtParameter>"
+        "</Card>"
+        "</Protocol></PrintProtocol></PrintOut>"
+    )
+    protos = _parse_printprot_xml(xml)
+    assert protos[0]["name"] == "SIEMENS MAGNETOM ConnectomA syngo MR D11"
+
+
+# ---------------------------------------------------------------------------
+# dicompare/schemas/__init__.py
+# ---------------------------------------------------------------------------
+import dicompare.schemas as schemas_pkg
+
+
+def test_list_bundled_schemas_glob_fallback(monkeypatch, tmp_path):
+    """When index.json is absent, list_bundled_schemas globs *.json."""
+    (tmp_path / "a_schema.json").write_text("{}")
+    (tmp_path / "b_schema.json").write_text("{}")
+    monkeypatch.setattr(schemas_pkg, "_SCHEMAS_DIR", tmp_path)
+    result = schemas_pkg.list_bundled_schemas()
+    assert result == ["a_schema.json", "b_schema.json"]
+
+
+def test_load_all_bundled_schemas_handles_load_error(monkeypatch, tmp_path):
+    """A schema that fails to load is skipped with a warning, not raised."""
+    (tmp_path / "broken.json").write_text("{ not valid json")
+    monkeypatch.setattr(schemas_pkg, "_SCHEMAS_DIR", tmp_path)
+    result = schemas_pkg.load_all_bundled_schemas()
+    assert "broken.json" not in result
+
+
+# ---------------------------------------------------------------------------
+# dicompare/schema/build_schema.py
+# ---------------------------------------------------------------------------
+from dicompare.schema.build_schema import build_schema
+
+
+def test_build_schema_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        build_schema(pd.DataFrame())
+
+
+def test_build_schema_multi_field_nested_tuple_unwrap():
+    """Multi-field series where a value is a single-element tuple of a tuple is unwrapped."""
+    df = pd.DataFrame(
+        {
+            "Acquisition": ["A", "A"],
+            "PatientName": ["p", "p"],
+            "EchoTime": [1.0, 2.0],
+            # A value that is a 1-element tuple wrapping another tuple.
+            "ImageType": [((1, 2),), ((3, 4),)],
+        }
+    )
+    schema = build_schema(
+        df, reference_fields=["PatientName", "EchoTime", "ImageType"]
+    )
+    (acq,) = schema["acquisitions"].values()
+    # Two varying fields (EchoTime, ImageType) -> two series.
+    assert len(acq["series"]) == 2
+    # The nested-tuple value should be unwrapped to the inner tuple.
+    all_values = [f["value"] for s in acq["series"] for f in s["fields"] if f["field"] == "ImageType"]
+    assert (1, 2) in all_values or [1, 2] in [list(v) if isinstance(v, tuple) else v for v in all_values]
+
+
+def test_build_schema_single_varying_tuple_value_unwrap():
+    """A single varying field whose values are tuples exercises the tuple-unwrap path."""
+    df = pd.DataFrame(
+        {
+            "Acquisition": ["A", "A"],
+            "PatientName": ["p", "p"],
+            "ImageType": [("ORIGINAL", "PRIMARY"), ("DERIVED", "SECONDARY")],
+        }
+    )
+    schema = build_schema(df, reference_fields=["PatientName", "ImageType"])
+    acqs = schema["acquisitions"]
+    assert len(acqs) == 1
+    (acq,) = acqs.values()
+    # ImageType varies -> becomes series; PatientName constant -> acquisition field.
+    assert len(acq["series"]) == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/dicompare/tests/test_web_utils_coverage.py
+++ b/dicompare/tests/test_web_utils_coverage.py
@@ -1,0 +1,1179 @@
+"""
+Additional coverage tests for dicompare.interface.web_utils.
+
+These exercise the plain-Python (non-Pyodide) surface of the web interface
+layer: protocol loading, UI acquisition formatting, direct validation,
+schema (re)building, dictionary search, and JSON serialization edge cases.
+
+Pyodide-only branches (JSProxy conversion, ``pyodide.ffi.to_js`` progress
+callbacks) are intentionally not forced here.
+"""
+
+import json
+import os
+import tempfile
+import unittest.mock as mock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from dicompare.interface.web_utils import (
+    analyze_dicom_files_for_ui,
+    validate_acquisition_direct,
+    load_protocol_for_ui,
+    load_gradient_file_for_ui,
+    search_dicom_dictionary,
+    build_schema_from_ui_acquisitions,
+    attach_gradient_files_to_acquisitions,
+    make_json_serializable,
+    _cache_session,
+    _get_cached_session,
+    _gradient_file_kind,
+    _gradient_base_name,
+    _acq_field_value,
+    _is_diffusion_acquisition,
+    _merge_descriptor_fields,
+)
+from dicompare.tests.test_dicom_factory import (
+    create_test_dicom_series,
+    create_multi_echo_series,
+)
+
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+PRO_DIR = os.path.join(FIXTURES, "pro_files")
+GRAD_DIR = os.path.join(FIXTURES, "gradients")
+PRINTPROT_DIR = os.path.join(FIXTURES, "printprot")
+
+
+# ---------------------------------------------------------------------------
+# make_json_serializable
+# ---------------------------------------------------------------------------
+
+class TestMakeJsonSerializable:
+    def test_numpy_scalars_and_arrays(self):
+        data = {
+            "arr": np.array([1, 2, 3]),
+            "int": np.int64(42),
+            "float": np.float64(3.5),
+        }
+        out = make_json_serializable(data)
+        assert out == {"arr": [1, 2, 3], "int": 42, "float": 3.5}
+        # Result must be JSON-encodable
+        json.dumps(out)
+
+    def test_nan_inf_and_none_become_none(self):
+        out = make_json_serializable(
+            {"a": np.nan, "b": np.float64("inf"), "c": None, "d": float("nan")}
+        )
+        assert out == {"a": None, "b": None, "c": None, "d": None}
+
+    def test_pandas_series_and_dataframe(self):
+        series = pd.Series([1, 2, 3])
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        assert make_json_serializable(series) == [1, 2, 3]
+        assert make_json_serializable(df) == [
+            {"x": 1, "y": 3},
+            {"x": 2, "y": 4},
+        ]
+
+    def test_nested_and_tuple_and_numpy_bool(self):
+        data = {"nested": [(np.int32(1), np.bool_(True)), {"k": np.array([5])}]}
+        out = make_json_serializable(data)
+        assert out == {"nested": [[1, True], {"k": [5]}]}
+        json.dumps(out)
+
+    def test_plain_python_passthrough(self):
+        assert make_json_serializable("hello") == "hello"
+        assert make_json_serializable(7) == 7
+
+
+# ---------------------------------------------------------------------------
+# load_protocol_for_ui
+# ---------------------------------------------------------------------------
+
+def _read(path, binary=True):
+    with open(path, "rb" if binary else "r") as f:
+        return f.read()
+
+
+def _assert_ui_acquisition_shape(acq):
+    for key in (
+        "id",
+        "protocolName",
+        "seriesDescription",
+        "totalFiles",
+        "acquisitionFields",
+        "seriesFields",
+        "series",
+        "metadata",
+    ):
+        assert key in acq, f"missing key {key}"
+    # Every acquisition field carries the UI contract fields.
+    for field in acq["acquisitionFields"]:
+        for k in ("tag", "name", "keyword", "value", "vr", "level", "dataType", "fieldType"):
+            assert k in field
+        assert field["level"] == "acquisition"
+    # Must be JSON serializable.
+    json.dumps(acq)
+
+
+class TestLoadProtocolForUi:
+    def test_pro_file(self):
+        content = _read(os.path.join(PRO_DIR, "PRODUCT__ep2d_bold__p2_sms1.pro"))
+        result = load_protocol_for_ui(content, "bold.pro", "pro")
+        assert isinstance(result, list)
+        assert len(result) == 1
+        acq = result[0]
+        _assert_ui_acquisition_shape(acq)
+        assert acq["protocolName"] == "PRODUCT__ep2d_bold__p2_sms1"
+        assert acq["totalFiles"] == 1
+        assert acq["metadata"]["source"] == "siemens_protocol"
+        assert acq["metadata"]["originalFileName"] == "bold.pro"
+        assert len(acq["acquisitionFields"]) > 0
+
+    def test_pro_diffusion_file_has_list_values(self):
+        content = _read(os.path.join(PRO_DIR, "PRODUCT__ep2d_diff__p3_sms1.pro"))
+        result = load_protocol_for_ui(content, "diff.pro", "pro")
+        acq = result[0]
+        _assert_ui_acquisition_shape(acq)
+        # DiffusionBValue is a multi-element list -> list dataType.
+        bval = _acq_field_value(acq, "DiffusionBValue")
+        assert isinstance(bval, list)
+
+    def test_examcard_file(self):
+        content = _read(os.path.join(REPO_ROOT, "DUAL_ECHO_EPI.ExamCard"))
+        result = load_protocol_for_ui(content, "DUAL_ECHO_EPI.ExamCard", "examcard")
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        for acq in result:
+            _assert_ui_acquisition_shape(acq)
+            assert acq["metadata"]["source"] == "philips_examcard"
+        # At least one exam-card scan should carry series with fields.
+        assert any(len(a["series"]) > 0 for a in result)
+
+    def test_examcard_second_fixture(self):
+        content = _read(os.path.join(REPO_ROOT, "SSdense_July2024.ExamCard"))
+        result = load_protocol_for_ui(content, "SSdense_July2024.ExamCard", "examcard")
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        for acq in result:
+            _assert_ui_acquisition_shape(acq)
+
+    def test_printprot_file(self):
+        content = _read(os.path.join(PRINTPROT_DIR, "AxonDiameterProtocol.txt"))
+        result = load_protocol_for_ui(content, "AxonDiameterProtocol.txt", "printprot")
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        for acq in result:
+            _assert_ui_acquisition_shape(acq)
+            assert acq["metadata"]["source"] == "siemens_printprot"
+
+    def test_lxprotocol_file(self):
+        from dicompare.tests.test_lxprotocol import SAMPLE_LXPROTOCOL
+
+        result = load_protocol_for_ui(
+            SAMPLE_LXPROTOCOL.encode("utf-8"), "LxProtocol", "lxprotocol"
+        )
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        for acq in result:
+            _assert_ui_acquisition_shape(acq)
+            assert acq["metadata"]["source"] == "ge_lxprotocol"
+
+    def test_exar1_file(self):
+        from dicompare.tests.test_pro_coverage import (
+            _build_exar,
+            PROTO_TEXT_MULTIECHO,
+        )
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "test.exar1")
+            _build_exar(path, [PROTO_TEXT_MULTIECHO])
+            with open(path, "rb") as fh:
+                content = fh.read()
+        result = load_protocol_for_ui(content, "test.exar1", "exar1")
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        for acq in result:
+            _assert_ui_acquisition_shape(acq)
+            assert acq["metadata"]["source"] == "siemens_exar"
+        # Multi-echo protocol should expand into series.
+        assert any(len(a["series"]) > 0 for a in result)
+
+    def test_unknown_file_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown file type"):
+            load_protocol_for_ui(b"whatever", "x.bin", "not_a_type")
+
+    def test_single_element_lists_and_empty_list_data_types(self):
+        # Exercise the single-element-array normalization and empty-list data
+        # type branches via a mocked pro loader.
+        fake = {
+            "acquisition_info": {"protocol_name": "MockProt"},
+            "fields": [
+                {"field": "EchoTime", "value": [5.0]},        # single numeric
+                {"field": "ProtocolName", "value": ["abc"]},  # single string
+                {"field": "ImageType", "value": []},          # empty list
+                {"field": "FlipAngle", "value": 9.0},         # scalar number
+                {"field": "ScanOptions", "value": ["A", "B"]},  # multi string list
+            ],
+            "series": [],
+        }
+        with mock.patch(
+            "dicompare.io.load_pro_file_schema_format", return_value=fake
+        ):
+            result = load_protocol_for_ui(b"x", "mock.pro", "pro")
+        acq = result[0]
+        by_name = {f["name"]: f for f in acq["acquisitionFields"]}
+        assert by_name["EchoTime"]["value"] == 5.0
+        assert by_name["EchoTime"]["dataType"] == "number"
+        assert by_name["ProtocolName"]["value"] == "abc"
+        assert by_name["ProtocolName"]["dataType"] == "string"
+        assert by_name["ImageType"]["value"] == []
+        assert by_name["ImageType"]["dataType"] == "list_string"
+        assert by_name["ScanOptions"]["dataType"] == "list_string"
+
+    def test_vr_lookup_exception_falls_back_to_LO(self):
+        fake = {
+            "acquisition_info": {"protocol_name": "MockProt"},
+            "fields": [{"field": "EchoTime", "value": 5.0}],
+            "series": [
+                {"name": "S1", "fields": [{"field": "FlipAngle", "value": 9}]},
+            ],
+        }
+        with mock.patch(
+            "dicompare.io.load_pro_file_schema_format", return_value=fake
+        ), mock.patch(
+            "pydicom.datadict.dictionary_VR", side_effect=KeyError("boom")
+        ):
+            result = load_protocol_for_ui(b"x", "mock.pro", "pro")
+        acq = result[0]
+        assert acq["acquisitionFields"][0]["vr"] == "LO"
+
+    def test_series_fields_present_for_multi_series_protocol(self):
+        # The dual-echo exam card expands into series; verify seriesFields carry
+        # a 'values' array and 'series' carries 'fields' arrays.
+        content = _read(os.path.join(REPO_ROOT, "DUAL_ECHO_EPI.ExamCard"))
+        result = load_protocol_for_ui(content, "DUAL_ECHO_EPI.ExamCard", "examcard")
+        multi = [a for a in result if a["series"]]
+        assert multi, "expected at least one acquisition with series"
+        acq = multi[0]
+        for sf in acq["seriesFields"]:
+            assert "values" in sf and isinstance(sf["values"], list)
+            assert sf["level"] == "series"
+        for series in acq["series"]:
+            assert "name" in series
+            assert isinstance(series["fields"], list)
+
+
+# ---------------------------------------------------------------------------
+# load_gradient_file_for_ui
+# ---------------------------------------------------------------------------
+
+class TestLoadGradientFileForUi:
+    def test_dvs_produces_derived_fields(self):
+        dvs = _read(
+            os.path.join(GRAD_DIR, "DiffusionVectors_AxonDiameter_ERJV.dvs"),
+            binary=False,
+        )
+        result = load_gradient_file_for_ui({"dvs": dvs}, b_max=1000.0)
+        assert "fields" in result
+        names = {f["name"] for f in result["fields"]}
+        assert "NumberOfDiffusionShells" in names
+        assert "DiffusionBValues" in names
+        for f in result["fields"]:
+            assert f["fieldType"] == "derived"
+            assert f["level"] == "acquisition"
+            assert "dataType" in f
+        json.dumps(result)
+
+    def test_dvs_requires_b_max(self):
+        with pytest.raises(ValueError, match="b_max"):
+            load_gradient_file_for_ui({"dvs": "irrelevant"})
+
+    def test_bvec_bval_pair(self):
+        # 3 directions: one b0 and two shells.
+        bval = "0 1000 1000"
+        bvec = "0 1 0\n0 0 1\n0 0 0"
+        result = load_gradient_file_for_ui({"bvec": bvec, "bval": bval})
+        assert "fields" in result
+        names = {f["name"] for f in result["fields"]}
+        assert "NumberOfDiffusionVolumes" in names
+
+    def test_missing_inputs_raises(self):
+        with pytest.raises(ValueError, match="Provide either"):
+            load_gradient_file_for_ui({"foo": "bar"})
+
+    def test_data_type_classification(self):
+        # Force a descriptor dict with a mix of value types to exercise
+        # the internal _data_type helper across number/list/string branches.
+        fake = {
+            "AScalar": 5,
+            "AList": [1, 2, 3],
+            "AStrList": ["a", "b"],
+            "AString": "full-sphere",
+        }
+        with mock.patch(
+            "dicompare.io.descriptors_from_dvs", return_value=fake
+        ):
+            result = load_gradient_file_for_ui({"dvs": "x"}, b_max=1.0)
+        by_name = {f["name"]: f for f in result["fields"]}
+        assert by_name["AScalar"]["dataType"] == "number"
+        assert by_name["AList"]["dataType"] == "list_number"
+        assert by_name["AStrList"]["dataType"] == "list_string"
+        assert by_name["AString"]["dataType"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# search_dicom_dictionary
+# ---------------------------------------------------------------------------
+
+class TestSearchDicomDictionary:
+    # Exercises the real pydicom DicomDictionary (tag_int -> entry tuple).
+
+    def test_search_by_keyword(self):
+        results = search_dicom_dictionary("EchoTime", limit=50)
+        match = [r for r in results if r["keyword"] == "EchoTime"]
+        assert match, "EchoTime should be found"
+        assert match[0]["tag"] == "0018,0081"
+        assert "suggested_data_type" in match[0]
+        json.dumps(results)  # results must be JSON-serializable
+
+    def test_search_by_tag_string(self):
+        results = search_dicom_dictionary("0018,0080", limit=10)
+        assert any(r["keyword"] == "RepetitionTime" for r in results)
+
+    def test_limit_is_respected(self):
+        results = search_dicom_dictionary("0018", limit=2)
+        assert len(results) == 2
+
+    def test_no_match_returns_empty(self):
+        results = search_dicom_dictionary("zzz_no_such_field_xyzzy", limit=10)
+        assert results == []
+
+    def test_multivalue_becomes_list_type(self):
+        # AcquisitionMatrix has VM > 1 so its suggested type should be listified.
+        results = search_dicom_dictionary("AcquisitionMatrix", limit=10)
+        match = [r for r in results if r["keyword"] == "AcquisitionMatrix"]
+        assert match
+        assert match[0]["suggested_data_type"].startswith("list_") or \
+            match[0]["suggested_data_type"] == "string"
+
+    def test_dictionary_lookup_failure_falls_back(self):
+        # If per-tag lookups raise, the except branch supplies UN/1/keyword.
+        with mock.patch(
+            "pydicom.datadict.dictionary_VR", side_effect=KeyError("boom")
+        ):
+            results = search_dicom_dictionary("EchoTime", limit=5)
+        assert any(r["vr"] == "UN" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# build_schema_from_ui_acquisitions
+# ---------------------------------------------------------------------------
+
+def _sample_ui_acquisition():
+    return {
+        "id": "t1",
+        "protocolName": "T1_MPRAGE",
+        "seriesDescription": "T1w anatomical",
+        "detailedDescription": "detail",
+        "tags": ["anatomical"],
+        "acquisitionFields": [
+            {
+                "tag": "0018,0080",
+                "name": "RepetitionTime",
+                "keyword": "RepetitionTime",
+                "value": 2300,
+                "validationRule": {"type": "exact"},
+            },
+            {
+                "tag": "0018,0081",
+                "name": "EchoTime",
+                "keyword": "EchoTime",
+                "value": 2.98,
+                "validationRule": {"type": "tolerance", "value": 3.0, "tolerance": 0.5},
+            },
+            {
+                "tag": "0018,1314",
+                "name": "FlipAngle",
+                "keyword": "FlipAngle",
+                "value": 9,
+                "validationRule": {"type": "range", "min": 5, "max": 15},
+            },
+            {
+                "tag": "0008,0008",
+                "name": "ImageType",
+                "keyword": "ImageType",
+                "value": ["ORIGINAL", "PRIMARY"],
+                "validationRule": {"type": "contains", "contains": "PRIMARY"},
+            },
+        ],
+        "series": [
+            {
+                "name": "Series 01",
+                "fields": [
+                    {
+                        "name": "EchoTime",
+                        "tag": "0018,0081",
+                        "value": 2.98,
+                        "validationRule": {"type": "exact"},
+                    }
+                ],
+            }
+        ],
+    }
+
+
+class TestBuildSchemaFromUiAcquisitions:
+    def test_basic_structure_and_validation_rules(self):
+        acq = _sample_ui_acquisition()
+        schema = build_schema_from_ui_acquisitions(
+            [acq], {"name": "My Schema", "version": "2.0", "authors": ["Ada"]}
+        )
+        assert schema["name"] == "My Schema"
+        assert schema["version"] == "2.0"
+        assert schema["authors"] == ["Ada"]
+        assert "T1_MPRAGE" in schema["acquisitions"]
+        entry = schema["acquisitions"]["T1_MPRAGE"]
+        assert entry["description"] == "T1w anatomical"
+        assert entry["detailed_description"] == "detail"
+        assert entry["tags"] == ["anatomical"]
+
+        fields_by_name = {f["field"]: f for f in entry["fields"]}
+        # exact -> value
+        assert fields_by_name["RepetitionTime"]["value"] == 2300
+        # tolerance -> value + tolerance
+        assert fields_by_name["EchoTime"]["value"] == 3.0
+        assert fields_by_name["EchoTime"]["tolerance"] == 0.5
+        # range -> min/max, no value
+        assert fields_by_name["FlipAngle"]["min"] == 5
+        assert fields_by_name["FlipAngle"]["max"] == 15
+        assert "value" not in fields_by_name["FlipAngle"]
+        # contains
+        assert fields_by_name["ImageType"]["contains"] == "PRIMARY"
+        # Series present
+        assert len(entry["series"]) == 1
+        json.dumps(schema)
+
+    def test_contains_any_all_and_missing_rule_data(self):
+        acq = {
+            "protocolName": "Test",
+            "acquisitionFields": [
+                {
+                    "keyword": "A",
+                    "value": [1, 2],
+                    "validationRule": {"type": "contains_any", "contains_any": [1]},
+                },
+                {
+                    "keyword": "B",
+                    "value": [1, 2],
+                    "validationRule": {"type": "contains_all", "contains_all": [1, 2]},
+                },
+                # tolerance rule missing tolerance -> falls back to value
+                {
+                    "keyword": "C",
+                    "value": 5,
+                    "validationRule": {"type": "tolerance"},
+                },
+                # contains rule missing contains -> falls back to value
+                {
+                    "keyword": "D",
+                    "value": "x",
+                    "validationRule": {"type": "contains"},
+                },
+            ],
+            "series": [],
+        }
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        fields = {f["field"]: f for f in schema["acquisitions"]["Test"]["fields"]}
+        assert fields["A"]["contains_any"] == [1]
+        assert fields["B"]["contains_all"] == [1, 2]
+        assert fields["C"]["value"] == 5
+        assert fields["D"]["value"] == "x"
+
+    def test_defaults_when_metadata_empty(self):
+        acq = {"protocolName": "P", "acquisitionFields": [], "series": []}
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        assert schema["name"] == "Generated Schema"
+        assert schema["version"] == "1.0"
+        assert schema["authors"] == []
+
+    def test_series_object_format_and_images(self):
+        acq = {
+            "protocolName": "P",
+            "acquisitionFields": [],
+            "images": ["img_acq"],
+            "series": [
+                {
+                    "name": "S1",
+                    "images": ["img1"],
+                    # object-format fields (dict, not array)
+                    "fields": {
+                        "EchoTime": {"value": 5, "validationRule": {"type": "exact"}},
+                    },
+                }
+            ],
+        }
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        entry = schema["acquisitions"]["P"]
+        assert entry["images"] == ["img_acq"]
+        assert len(entry["series"]) == 1
+        assert entry["series"][0]["images"] == ["img1"]
+        assert entry["series"][0]["fields"][0]["field"] == "EchoTime"
+
+    def test_validation_functions_become_rules(self):
+        acq = {
+            "protocolName": "Rules Acq",
+            "acquisitionFields": [],
+            "series": [],
+            "validationFunctions": [
+                {
+                    "name": "check_thing",
+                    "description": "desc",
+                    "implementation": "pass",
+                    "parameters": {"p": 1},
+                    "fields": ["EchoTime"],
+                    "testCases": [],
+                }
+            ],
+        }
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        rules = schema["acquisitions"]["Rules Acq"]["rules"]
+        assert len(rules) == 1
+        assert rules[0]["name"] == "check_thing"
+        assert rules[0]["fields"] == ["EchoTime"]
+        assert "id" in rules[0]
+
+    def test_uses_id_when_protocol_name_absent(self):
+        acq = {"id": "fallback_id", "acquisitionFields": [], "series": []}
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        assert "fallback_id" in schema["acquisitions"]
+
+    def test_series_field_rule_types(self):
+        # Exercise every rule branch on series fields (tolerance/range/contains/
+        # contains_any/contains_all and their fall-back-to-value forms).
+        acq = {
+            "protocolName": "P",
+            "acquisitionFields": [],
+            "series": [
+                {
+                    "name": "S1",
+                    "fields": [
+                        {"name": "Tol", "value": 5,
+                         "validationRule": {"type": "tolerance", "value": 5.0, "tolerance": 0.1}},
+                        {"name": "TolFallback", "value": 6,
+                         "validationRule": {"type": "tolerance"}},
+                        {"name": "Rng", "value": 5,
+                         "validationRule": {"type": "range", "min": 1, "max": 10}},
+                        {"name": "Con", "value": ["a"],
+                         "validationRule": {"type": "contains", "contains": "a"}},
+                        {"name": "ConFallback", "value": ["a"],
+                         "validationRule": {"type": "contains"}},
+                        {"name": "Any", "value": [1],
+                         "validationRule": {"type": "contains_any", "contains_any": [1]}},
+                        {"name": "AnyFallback", "value": [1],
+                         "validationRule": {"type": "contains_any"}},
+                        {"name": "All", "value": [1, 2],
+                         "validationRule": {"type": "contains_all", "contains_all": [1, 2]}},
+                        {"name": "AllFallback", "value": [1, 2],
+                         "validationRule": {"type": "contains_all"}},
+                    ],
+                }
+            ],
+        }
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        series = schema["acquisitions"]["P"]["series"][0]
+        fields = {f["field"]: f for f in series["fields"]}
+        assert fields["Tol"]["tolerance"] == 0.1
+        assert fields["TolFallback"]["value"] == 6
+        assert fields["Rng"]["min"] == 1 and fields["Rng"]["max"] == 10
+        assert fields["Con"]["contains"] == "a"
+        assert fields["ConFallback"]["value"] == ["a"]
+        # Series fields carrying only contains_any/contains_all constraints (and
+        # no 'value') are filtered out by the constraint check, but their
+        # fallback-to-value forms survive.
+        assert "Any" not in fields
+        assert "All" not in fields
+        assert fields["AnyFallback"]["value"] == [1]
+        assert fields["AllFallback"]["value"] == [1, 2]
+
+    def test_acq_contains_any_all_fallback_to_value(self):
+        acq = {
+            "protocolName": "P",
+            "acquisitionFields": [
+                {"keyword": "A", "value": [1],
+                 "validationRule": {"type": "contains_any"}},
+                {"keyword": "B", "value": [1, 2],
+                 "validationRule": {"type": "contains_all"}},
+            ],
+            "series": [],
+        }
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        fields = {f["field"]: f for f in schema["acquisitions"]["P"]["fields"]}
+        assert fields["A"]["value"] == [1]
+        assert fields["B"]["value"] == [1, 2]
+
+    def test_complex_value_object_is_unwrapped(self):
+        # A field whose 'value' is itself a dict carrying validationRule/dataType
+        # is unwrapped: the nested validationRule is read, then the scalar value
+        # is extracted from the dict.
+        acq = {
+            "protocolName": "P",
+            "acquisitionFields": [
+                {"keyword": "EchoTime",
+                 "value": {"value": 42, "dataType": "number",
+                           "validationRule": {"type": "exact"}}},
+            ],
+            "series": [],
+        }
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        fields = {f["field"]: f for f in schema["acquisitions"]["P"]["fields"]}
+        assert fields["EchoTime"]["value"] == 42
+
+    def test_series_field_without_constraint_is_dropped(self):
+        # A series field whose rule yields no constraint keys is omitted, and a
+        # series with no remaining fields is not added.
+        acq = {
+            "protocolName": "P",
+            "acquisitionFields": [],
+            "series": [
+                {
+                    "name": "S1",
+                    "fields": [
+                        {"name": "X", "validationRule": {"type": "range"}},
+                    ],
+                }
+            ],
+        }
+        schema = build_schema_from_ui_acquisitions([acq], {})
+        assert schema["acquisitions"]["P"]["series"] == []
+
+
+# ---------------------------------------------------------------------------
+# validate_acquisition_direct
+# ---------------------------------------------------------------------------
+
+class TestValidateAcquisitionDirect:
+    def _schema_content(self, acq):
+        schema = build_schema_from_ui_acquisitions(
+            [acq], {"name": "S", "version": "1.0", "authors": ["a"]}
+        )
+        return json.dumps(schema)
+
+    def test_pass_results(self):
+        acq = _sample_ui_acquisition()
+        content = self._schema_content(acq)
+        results = validate_acquisition_direct(acq, content, 0)
+        assert isinstance(results, list)
+        assert len(results) > 0
+        for r in results:
+            for k in ("fieldPath", "fieldName", "status", "message", "validationType"):
+                assert k in r
+        by_field = {r["fieldName"]: r for r in results if r["validationType"] == "field"}
+        assert by_field["RepetitionTime"]["status"] == "pass"
+        json.dumps(results)
+
+    def test_fail_on_mismatch(self):
+        acq = _sample_ui_acquisition()
+        content = self._schema_content(acq)
+        # Mutate the actual data so RepetitionTime disagrees with schema.
+        bad = json.loads(json.dumps(acq))
+        for f in bad["acquisitionFields"]:
+            if f["keyword"] == "RepetitionTime":
+                f["value"] = 9999
+        results = validate_acquisition_direct(bad, content, 0)
+        rt = [r for r in results if r["fieldName"] == "RepetitionTime"]
+        assert rt and rt[0]["status"] == "fail"
+
+    def test_no_series_uses_base_row(self):
+        acq = {
+            "protocolName": "NoSeries",
+            "acquisitionFields": [
+                {
+                    "keyword": "RepetitionTime",
+                    "tag": "0018,0080",
+                    "value": 100,
+                    "validationRule": {"type": "exact"},
+                }
+            ],
+            "series": [],
+        }
+        content = self._schema_content(acq)
+        results = validate_acquisition_direct(acq, content, 0)
+        assert len(results) >= 1
+
+    def test_single_acquisition_no_index(self):
+        acq = _sample_ui_acquisition()
+        content = self._schema_content(acq)
+        # index None with a single-acquisition schema is allowed.
+        results = validate_acquisition_direct(acq, content, None)
+        assert len(results) > 0
+
+    def test_empty_schema_raises(self):
+        content = json.dumps({"name": "S", "version": "1.0", "authors": [], "acquisitions": {}})
+        with pytest.raises(ValueError, match="no acquisitions"):
+            validate_acquisition_direct(_sample_ui_acquisition(), content, 0)
+
+    def test_invalid_index_raises(self):
+        acq = _sample_ui_acquisition()
+        content = self._schema_content(acq)
+        with pytest.raises(ValueError, match="Invalid acquisition index"):
+            validate_acquisition_direct(acq, content, 5)
+
+    def test_multiple_acquisitions_without_index_raises(self):
+        acq1 = _sample_ui_acquisition()
+        acq2 = _sample_ui_acquisition()
+        acq2["protocolName"] = "Second"
+        schema = build_schema_from_ui_acquisitions(
+            [acq1, acq2], {"name": "S", "version": "1.0", "authors": ["a"]}
+        )
+        content = json.dumps(schema)
+        with pytest.raises(ValueError, match="Multiple acquisitions"):
+            validate_acquisition_direct(acq1, content, None)
+
+    def test_list_values_are_made_hashable(self):
+        acq = {
+            "protocolName": "ListAcq",
+            "sliceCount": 3,
+            "acquisitionFields": [
+                {
+                    "keyword": "ImageType",
+                    "tag": "0008,0008",
+                    "value": ["ORIGINAL", "PRIMARY"],
+                    "validationRule": {"type": "exact"},
+                }
+            ],
+            "series": [],
+        }
+        content = self._schema_content(acq)
+        # Should not raise despite list-valued field.
+        results = validate_acquisition_direct(acq, content, 0)
+        assert isinstance(results, list)
+
+    def test_temp_schema_file_is_cleaned_up(self):
+        acq = _sample_ui_acquisition()
+        content = self._schema_content(acq)
+        before = set(os.listdir(tempfile.gettempdir()))
+        validate_acquisition_direct(acq, content, 0)
+        after = set(os.listdir(tempfile.gettempdir()))
+        leaked = [p for p in (after - before) if p.endswith(".json")]
+        assert not leaked
+
+    def test_status_and_type_branches_via_mock(self):
+        # Craft compliance results that exercise the na / warning / rule /
+        # series status and validation-type branches.
+        acq = _sample_ui_acquisition()
+        content = self._schema_content(acq)
+        fake_results = [
+            {"field": "F1", "status": "na", "message": "not applicable"},
+            {"field": "F2", "status": "warning", "message": "warn", "expected": 1, "value": [2]},
+            {"field": "F3", "status": "ok", "message": "ok"},
+            {"field": "F4", "status": "error", "message": "err"},
+            # Unknown status -> falls back to 'passed' boolean (False -> fail).
+            {"field": "F5", "message": "weird", "passed": False},
+            {"field": "F6", "message": "boolpass", "passed": True},
+            # Series-level result.
+            {"field": "F7", "status": "pass", "series": "Series 01", "message": "s"},
+            # Rule result.
+            {"field": "F8", "rule_name": "MyRule", "passed": True, "expected": "yes", "message": "r"},
+        ]
+        with mock.patch(
+            "dicompare.validation.check_acquisition_compliance",
+            return_value=fake_results,
+        ):
+            results = validate_acquisition_direct(acq, content, 0)
+        by_field = {r["fieldName"]: r for r in results}
+        assert by_field["F1"]["status"] == "na"
+        assert by_field["F2"]["status"] == "warning"
+        assert by_field["F2"]["actualValue"] == 2  # extracted from list
+        assert by_field["F3"]["status"] == "pass"
+        assert by_field["F4"]["status"] == "fail"
+        assert by_field["F5"]["status"] == "fail"
+        assert by_field["F6"]["status"] == "pass"
+        assert by_field["F7"]["validationType"] == "series"
+        assert by_field["F7"]["seriesName"] == "Series 01"
+        assert by_field["F8"]["validationType"] == "rule"
+        assert by_field["F8"]["rule_name"] == "MyRule"
+        assert by_field["F8"]["expectedValue"] == "yes"
+
+
+# ---------------------------------------------------------------------------
+# analyze_dicom_files_for_ui
+# ---------------------------------------------------------------------------
+
+class TestAnalyzeDicomFilesForUi:
+    @pytest.mark.asyncio
+    async def test_single_acquisition(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _, dicom_bytes = create_test_dicom_series(
+                base_dir=tmp,
+                acquisition_name="T1_MPRAGE",
+                num_slices=3,
+                metadata_base={
+                    "RepetitionTime": 2300.0,
+                    "EchoTime": 2.98,
+                    "FlipAngle": 9.0,
+                    "SeriesDescription": "T1w",
+                },
+            )
+            result = await analyze_dicom_files_for_ui(dicom_bytes)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        acq = result[0]
+        for key in (
+            "id",
+            "protocolName",
+            "seriesDescription",
+            "totalFiles",
+            "sliceCount",
+            "acquisitionFields",
+            "seriesFields",
+            "series",
+            "seriesFileMapping",
+            "metadata",
+        ):
+            assert key in acq
+        assert acq["totalFiles"] == 3
+        assert acq["sliceCount"] == 3
+        assert len(acq["acquisitionFields"]) > 0
+        assert acq["metadata"]["source"] == "dicom_analysis"
+        json.dumps(result)
+
+    @pytest.mark.asyncio
+    async def test_multi_echo_produces_series(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _, dicom_bytes = create_multi_echo_series(
+                base_dir=tmp,
+                acquisition_name="MEGRE",
+                echo_times=[0.01, 0.02, 0.03],
+                num_slices_per_echo=2,
+            )
+            result = await analyze_dicom_files_for_ui(dicom_bytes)
+        assert len(result) == 1
+        acq = result[0]
+        # Varying EchoTime -> series fields with values and a file mapping.
+        assert len(acq["series"]) >= 2
+        assert len(acq["seriesFields"]) > 0
+        assert len(acq["seriesFileMapping"]) >= 2
+        for sf in acq["seriesFields"]:
+            assert isinstance(sf["values"], list)
+            assert sf["level"] == "series"
+
+    @pytest.mark.asyncio
+    async def test_error_raises_runtime_error(self):
+        # Empty input -> underlying analysis returns an error status, which the
+        # UI wrapper surfaces as RuntimeError.
+        with pytest.raises(RuntimeError):
+            await analyze_dicom_files_for_ui({})
+
+
+class TestAnalyzeDicomFilesForWebProgress:
+    """Exercise the progress-callback path of analyze_dicom_files_for_web.
+
+    The real code imports ``pyodide.ffi.to_js`` which only exists in a browser;
+    we inject a stub ``pyodide`` module so the progress branches run under
+    CPython. This covers the callback-wrapping and to_js progress reporting
+    blocks that are otherwise Pyodide-only.
+    """
+
+    @pytest.fixture
+    def fake_pyodide(self):
+        import sys
+        import types
+
+        fake_ffi = types.ModuleType("pyodide.ffi")
+        fake_ffi.to_js = lambda obj, **kw: obj
+        fake_pyodide = types.ModuleType("pyodide")
+        fake_pyodide.ffi = fake_ffi
+        saved = {k: sys.modules.get(k) for k in ("pyodide", "pyodide.ffi")}
+        sys.modules["pyodide"] = fake_pyodide
+        sys.modules["pyodide.ffi"] = fake_ffi
+        try:
+            yield
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    sys.modules.pop(k, None)
+                else:
+                    sys.modules[k] = v
+
+    @pytest.mark.asyncio
+    async def test_progress_callback_invoked(self, fake_pyodide):
+        from dicompare.interface.web_utils import analyze_dicom_files_for_web
+
+        calls = []
+
+        def callback(obj):
+            calls.append(obj)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            _, dicom_bytes = create_test_dicom_series(
+                base_dir=tmp,
+                acquisition_name="T1_MPRAGE",
+                num_slices=2,
+                metadata_base={"RepetitionTime": 2300.0, "EchoTime": 2.98},
+            )
+            result = await analyze_dicom_files_for_web(
+                dicom_bytes, ["RepetitionTime", "EchoTime"], callback
+            )
+
+        assert result["status"] == "success"
+        # The callback receives multiple progress objects (test ping + stages).
+        assert len(calls) >= 2
+        percentages = [c.get("percentage") for c in calls if isinstance(c, dict)]
+        assert 80 in percentages  # "Organizing acquisitions" stage
+
+    @pytest.mark.asyncio
+    async def test_field_type_none_duplicate_id_and_slice_count_branches(self):
+        # Feed a crafted web result + cached session to exercise the branches
+        # that fill in missing fieldType/tag, dedupe acquisition ids, build the
+        # series/file mapping, and compute sliceCount from a Siemens mosaic.
+        web_result = {
+            "status": "success",
+            "acquisitions": {
+                "Dup Acq": {
+                    "fields": [
+                        # Missing fieldType and tag -> get_tag_info fallback.
+                        {"field": "EchoTime", "value": 5},
+                    ],
+                    "series": [
+                        {
+                            "name": "Series 01",
+                            "fields": [{"field": "FlipAngle", "value": 9}],
+                        },
+                        {
+                            "name": "Series 02",
+                            "fields": [{"field": "FlipAngle", "value": 12}],
+                        },
+                    ],
+                },
+                # Same base id after normalization -> triggers dedupe counter.
+                "Dup-Acq": {
+                    "fields": [{"field": "RepetitionTime", "value": 2000}],
+                    "series": [],
+                },
+                # Third collision -> forces the dedupe while-loop to increment.
+                "Dup/Acq": {
+                    "fields": [{"field": "RepetitionTime", "value": 2500}],
+                    "series": [],
+                },
+            },
+        }
+
+        session_df = pd.DataFrame(
+            {
+                "Acquisition": ["Dup Acq", "Dup Acq", "Dup-Acq", "Dup/Acq"],
+                "SeriesDescription": ["desc1", "desc1", "desc2", "desc3"],
+                "FlipAngle": [9, 12, 9, 9],
+                "DICOM_Path": ["/a/1.dcm", "/a/2.dcm", "/b/1.dcm", "/c/1.dcm"],
+                "NumberOfImagesInMosaic": [40, 40, np.nan, np.nan],
+            }
+        )
+        metadata = {"available_fields": ["FlipAngle"]}
+
+        async def fake_web(*args, **kwargs):
+            return web_result
+
+        # Patch dictionary_VR to raise so the VR-lookup exception fallback
+        # (lines 357-359) is also exercised.
+        with mock.patch(
+            "dicompare.interface.web_utils.analyze_dicom_files_for_web",
+            side_effect=fake_web,
+        ), mock.patch(
+            "dicompare.interface.web_utils._get_cached_session",
+            return_value=(session_df, metadata, None),
+        ), mock.patch(
+            "pydicom.datadict.dictionary_VR", side_effect=KeyError("boom")
+        ):
+            result = await analyze_dicom_files_for_ui({"x.dcm": b"x"})
+
+        assert len(result) == 3
+        ids = [a["id"] for a in result]
+        # Deduplicated ids (base, base_2, base_3).
+        assert len(set(ids)) == 3
+        assert any(i.endswith("_2") for i in ids)
+        assert any(i.endswith("_3") for i in ids)
+        # VR fell back to 'LO' due to the raising dictionary_VR.
+        assert result[0]["acquisitionFields"][0]["vr"] == "LO"
+        first = result[0]
+        # fieldType filled in by get_tag_info fallback.
+        assert first["acquisitionFields"][0]["fieldType"] is not None
+        # Mosaic slice count picked up.
+        assert first["sliceCount"] == 40
+        # File mapping built from varying FlipAngle field.
+        assert len(first["seriesFileMapping"]) == 2
+        # seriesDescription derived from the DataFrame.
+        assert first["seriesDescription"] == "desc1"
+
+    @pytest.mark.asyncio
+    async def test_slice_count_from_unique_slice_location_and_no_varying(self):
+        web_result = {
+            "status": "success",
+            "acquisitions": {
+                "Acq": {
+                    "fields": [{"field": "EchoTime", "value": 5}],
+                    "series": [
+                        {"name": "Series 01", "fields": [{"field": "EchoTime", "value": 5}]},
+                    ],
+                },
+            },
+        }
+        session_df = pd.DataFrame(
+            {
+                "Acquisition": ["Acq", "Acq", "Acq"],
+                "SliceLocation": [0.0, 5.0, 10.0],
+                "DICOM_Path": ["/a/1.dcm", "/a/2.dcm", "/a/3.dcm"],
+                # EchoTime constant -> no varying fields -> single "Series 01".
+                "EchoTime": [5, 5, 5],
+            }
+        )
+        metadata = {"available_fields": ["EchoTime"]}
+
+        async def fake_web(*args, **kwargs):
+            return web_result
+
+        with mock.patch(
+            "dicompare.interface.web_utils.analyze_dicom_files_for_web",
+            side_effect=fake_web,
+        ), mock.patch(
+            "dicompare.interface.web_utils._get_cached_session",
+            return_value=(session_df, metadata, None),
+        ):
+            result = await analyze_dicom_files_for_ui({"x.dcm": b"x"})
+
+        acq = result[0]
+        # Unique SliceLocation count.
+        assert acq["sliceCount"] == 3
+        # No varying fields -> all files in one series.
+        assert list(acq["seriesFileMapping"].keys()) == ["Series 01"]
+
+
+# ---------------------------------------------------------------------------
+# Small pure helpers + session cache
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_gradient_file_kind(self):
+        assert _gradient_file_kind("a/b/Foo.dvs") == "dvs"
+        assert _gradient_file_kind("Foo.BVEC") == "bvec"
+        assert _gradient_file_kind("Foo.bval") == "bval"
+        assert _gradient_file_kind("Foo.txt") is None
+
+    def test_gradient_base_name(self):
+        assert _gradient_base_name("a/b/Foo.dvs") == "Foo"
+        assert _gradient_base_name("Bar.bvec") == "Bar"
+        assert _gradient_base_name("NoExt") == "NoExt"
+        assert _gradient_base_name("windows\\path\\Baz.dvs") == "Baz"
+
+    def test_acq_field_value(self):
+        acq = {
+            "acquisitionFields": [
+                {"keyword": "DiffusionBValue", "value": 1000},
+                {"name": "OnlyName", "value": 7},
+            ]
+        }
+        assert _acq_field_value(acq, "DiffusionBValue") == 1000
+        assert _acq_field_value(acq, "OnlyName") == 7
+        assert _acq_field_value(acq, "Missing") is None
+        assert _acq_field_value({}, "X") is None
+
+    def test_is_diffusion_acquisition(self):
+        assert _is_diffusion_acquisition(
+            {"acquisitionFields": [{"keyword": "DiffusionBValue", "value": 1000}]}
+        )
+        assert _is_diffusion_acquisition(
+            {"acquisitionFields": [{"keyword": "DiffusionDirectionSet", "value": "set"}]}
+        )
+        assert not _is_diffusion_acquisition(
+            {"acquisitionFields": [{"keyword": "EchoTime", "value": 5}]}
+        )
+
+    def test_merge_descriptor_fields_replaces_by_name(self):
+        existing = [
+            {"keyword": "A", "value": 1},
+            {"keyword": "B", "value": 2},
+        ]
+        incoming = [{"keyword": "B", "value": 99}, {"keyword": "C", "value": 3}]
+        merged = _merge_descriptor_fields(existing, incoming)
+        by_name = {f["keyword"]: f["value"] for f in merged}
+        assert by_name == {"A": 1, "B": 99, "C": 3}
+
+    def test_merge_descriptor_fields_handles_none_existing(self):
+        merged = _merge_descriptor_fields(None, [{"keyword": "A", "value": 1}])
+        assert merged == [{"keyword": "A", "value": 1}]
+
+    def test_session_cache_roundtrip(self):
+        df = pd.DataFrame({"Acquisition": ["a"], "EchoTime": [5]})
+        meta = {"total_files": 1}
+        analysis = {"status": "success"}
+        _cache_session(df, meta, analysis)
+        cached_df, cached_meta, cached_analysis = _get_cached_session()
+        pd.testing.assert_frame_equal(cached_df, df)
+        assert cached_meta == meta
+        assert cached_analysis == analysis
+        # It should be a copy, not the same object.
+        assert cached_df is not df
+
+    def test_session_cache_with_none(self):
+        _cache_session(None, None, None)
+        cached_df, cached_meta, cached_analysis = _get_cached_session()
+        assert cached_df is None
+        assert cached_meta == {}
+        assert cached_analysis == {}
+
+
+# ---------------------------------------------------------------------------
+# attach_gradient_files_to_acquisitions (branches not covered elsewhere)
+# ---------------------------------------------------------------------------
+
+class TestAttachGradientBranches:
+    def _dvs(self):
+        return _read(
+            os.path.join(GRAD_DIR, "DiffusionVectors_AxonDiameter_ERJV.dvs"),
+            binary=False,
+        )
+
+    def _diffusion_acq(self, name="DWI", b_value=1000):
+        return {
+            "id": name,
+            "protocolName": name,
+            "acquisitionFields": [
+                {"keyword": "DiffusionBValue", "value": b_value},
+            ],
+        }
+
+    def test_unknown_kind_file_is_ignored_and_dvs_falls_back(self):
+        # A non-gradient file is skipped; the .dvs then binds to the single
+        # diffusion acquisition via the fallback path.
+        acq = self._diffusion_acq()
+        files = [
+            {"name": "readme.txt", "content": "ignore me"},
+            {"name": "Foo.dvs", "content": self._dvs()},
+        ]
+        result = attach_gradient_files_to_acquisitions([acq], files)
+        assert [b["protocolName"] for b in result["bound"]] == ["DWI"]
+        assert result["unmatched"] == []
+        # Descriptors merged into the acquisition.
+        names = {f["keyword"] for f in acq["acquisitionFields"]}
+        assert "NumberOfDiffusionShells" in names
+
+    def test_bad_dvs_content_reported_unmatched(self):
+        acq = self._diffusion_acq()
+        result = attach_gradient_files_to_acquisitions(
+            [acq], [{"name": "Bar.dvs", "content": "garbage without vectors"}]
+        )
+        assert result["bound"] == []
+        assert result["unmatched"] == ["Bar"]
+
+    def test_non_numeric_bvalue_reported_unmatched(self):
+        acq = self._diffusion_acq(b_value="not-a-number")
+        result = attach_gradient_files_to_acquisitions(
+            [acq], [{"name": "Baz.dvs", "content": self._dvs()}]
+        )
+        assert result["bound"] == []
+        assert "Baz" in result["unmatched"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,19 +14,14 @@ asyncio_mode = "strict"
 source = ["dicompare"]
 omit = [
     "dicompare/tests/*",
-    # web_utils is the browser/Pyodide interface layer: it carries module-level
-    # session globals and only runs meaningfully inside a Pyodide runtime, so it
-    # is exercised by the web app's integration tests rather than unit tests here.
-    # Everything else -- including the core io/ parsers -- is measured.
-    "dicompare/interface/web_utils.py",
 ]
 
 [tool.coverage.report]
-# Realistic gate reflecting what the suite actually covers today (~69% excluding
-# the browser glue above). Raise this as coverage of the io/ parsers improves;
-# do not lower it. The previous 90% figure was only attainable by omitting the
-# four largest, most complex modules from measurement.
-fail_under = 65
+# Every non-test module is measured (no files omitted). Keep this at 90 and cover
+# new code rather than lowering the gate or omitting files. Genuinely unreachable
+# lines (e.g. Pyodide-only branches) should be marked with an explicit
+# "pragma: no cover" plus a comment, not excluded wholesale.
+fail_under = 90
 show_missing = true
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
## Summary
Adds comprehensive unit tests across the previously under-tested modules, stops omitting any source file from coverage, and raises the release gate from 65% to **90%** (actual total coverage is **98%**).

This makes the 90% gate real: it was previously only reachable by omitting the four largest modules from measurement. Now every non-test module is measured and covered.

## Coverage by module
| Module | Before | After |
|---|---|---|
| `io/dicom.py` | 42% | 99% |
| `io/pro.py` | 59% | 99% |
| `io/examcard.py` | 36% | 99% |
| `cli/main.py` + `cli/match.py` | 49% / 81% | 100% / 100% |
| `session/mapping.py` | 62% | 99% |
| `session/acquisition.py` | 88% | 97% |
| `data_utils.py` | 80% | 100% |
| `interface/web_utils.py` | omitted (22%) | 91% |
| `io/dicom_generator.py` | 78% | 98% |
| `schema/tags.py` | 76% | 94% |
| `io/printprot.py` | 91% | 99% |
| `validation/compliance.py` | 88% | 100% |

`web_utils.py` is now measured (no longer omitted); the only uncovered lines are genuinely Pyodide-only (browser JSProxy conversion and the sync dispatch path).

## Bugs fixed (surfaced by the new tests)
- **`search_dicom_dictionary` was fully broken** — it iterated `keyword_for_tag.items()`, but `keyword_for_tag` is a pydicom *function*, not a dict, so the DICOM tag search raised `AttributeError` on every call. Now iterates `DicomDictionary`.
- **`build_schema_from_ui_acquisitions` raised on complex value objects** — it read `validationRule` off `actual_value` *after* reassigning it to a scalar (`AttributeError`). Now reads `validationRule` before unwrapping the value.

## Testing
~555 new tests; full suite 1161 passing, 0 failures. `fail_under=90` verified to pass (98.02%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)